### PR TITLE
Propagating ansible_init variables

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -197,9 +197,30 @@ azimuth_caas_stackhpc_workstation_image: >-
     if azimuth_caas_stackhpc_workstation_enabled
     else None
   }}
+# Combine default and any extra workstation ansible collections
+azimuth_caas_stackhpc_workstation_init_collections_default: >-
+  {{ ansible_init_default_collections | default([]) }}
+azimuth_caas_stackhpc_workstation_init_collections_extra: []
+azimuth_caas_stackhpc_workstation_init_collections: >-
+  {{
+    azimuth_caas_stackhpc_workstation_init_collections_default +
+    azimuth_caas_stackhpc_workstation_init_collections_extra
+  }}
+# Combine default and any extra workstation ansible playbooks
+azimuth_caas_stackhpc_workstation_init_playbooks_default: >-
+  {{ ansible_init_default_playbooks | default([]) }}
+azimuth_caas_stackhpc_workstation_init_playbooks_extra: []
+azimuth_caas_stackhpc_workstation_init_playbooks: >-
+  {{
+    azimuth_caas_stackhpc_workstation_init_playbooks_default + 
+    azimuth_caas_stackhpc_workstation_init_playbooks_extra
+  }}
 # The default extra vars for templates in the StackHPC workstation
 azimuth_caas_stackhpc_workstation_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_workstation_image }}"
+  ansible_init_collections: "{{ azimuth_caas_stackhpc_workstation_init_collections }}"
+  azimuth_init_playbooks: "{{ azimuth_caas_stackhpc_workstation_init_playbooks }}"
+
 # extra_vars overrides for templates in the StackHPC workstation
 azimuth_caas_stackhpc_workstation_extra_vars_overrides: {}
 azimuth_caas_stackhpc_workstation_extra_vars: >-
@@ -300,9 +321,29 @@ azimuth_caas_stackhpc_repo2docker_image: >-
     if azimuth_caas_stackhpc_repo2docker_enabled
     else None
   }}
+# Combine default and any extra repo2docker ansible collections
+azimuth_caas_stackhpc_repo2docker_init_collections_default: >-
+  {{ ansible_init_default_collections | default([]) }}
+azimuth_caas_stackhpc_repo2docker_init_collections_extra: []
+azimuth_caas_stackhpc_repo2docker_init_collections: >-
+  {{
+    azimuth_caas_stackhpc_repo2docker_init_collections_default +
+    azimuth_caas_stackhpc_repo2docker_init_collections_extra
+  }}
+# Combine default and any extra repo2docker ansible playbooks
+azimuth_caas_stackhpc_repo2docker_init_playbooks_default: >-
+  {{ ansible_init_default_playbooks | default([]) }}
+azimuth_caas_stackhpc_repo2docker_init_playbooks_extra: []
+azimuth_caas_stackhpc_repo2docker_init_playbooks: >-
+  {{
+    azimuth_caas_stackhpc_repo2docker_init_playbooks_default + 
+    azimuth_caas_stackhpc_repo2docker_init_playbooks_extra
+  }}
 # The default extra vars for templates in the StackHPC repo2docker appliance
 azimuth_caas_stackhpc_repo2docker_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_repo2docker_image }}"
+  ansible_init_collections: "{{ azimuth_caas_stackhpc_repo2docker_init_collections }}"
+  azimuth_init_playbooks: "{{ azimuth_caas_stackhpc_repo2docker_init_playbooks }}"
 # extra_vars overrides for templates in the StackHPC repo2docker appliance
 azimuth_caas_stackhpc_repo2docker_extra_vars_overrides: {}
 azimuth_caas_stackhpc_repo2docker_extra_vars: >-
@@ -365,9 +406,29 @@ azimuth_caas_stackhpc_rstudio_image: >-
     if azimuth_caas_stackhpc_rstudio_enabled
     else None
   }}
+# Combine default and any extra rstudio ansible collections
+azimuth_caas_stackhpc_rstudio_init_collections_default: >-
+  {{ ansible_init_default_collections | default([]) }}
+azimuth_caas_stackhpc_rstudio_init_collections_extra: []
+azimuth_caas_stackhpc_rstudio_init_collections: >-
+  {{
+    azimuth_caas_stackhpc_rstudio_init_collections_default +
+    azimuth_caas_stackhpc_rstudio_init_collections_extra
+  }}
+# Combine default and any extra rstudio ansible playbooks
+azimuth_caas_stackhpc_rstudio_init_playbooks_default: >-
+  {{ ansible_init_default_playbooks | default([]) }}
+azimuth_caas_stackhpc_rstudio_init_playbooks_extra: []
+azimuth_caas_stackhpc_rstudio_init_playbooks: >-
+  {{
+    azimuth_caas_stackhpc_rstudio_init_playbooks_default + 
+    azimuth_caas_stackhpc_rstudio_init_playbooks_extra
+  }}
 # The default extra vars for templates in the StackHPC R-Studio appliance
 azimuth_caas_stackhpc_rstudio_extra_vars_defaults:
   cluster_image: "{{ azimuth_caas_stackhpc_rstudio_image }}"
+  ansible_init_collections: "{{ azimuth_caas_stackhpc_rstudio_init_collections }}"
+  azimuth_init_playbooks: "{{ azimuth_caas_stackhpc_rstudio_init_playbooks }}"
 # extra_vars overrides for templates in the StackHPC R-Studio appliance
 azimuth_caas_stackhpc_rstudio_extra_vars_overrides: {}
 azimuth_caas_stackhpc_rstudio_extra_vars: >-


### PR DESCRIPTION
Propergating extra vars for ansible_init for workstation, r-studio, and repo2docker