### PR TITLE
Use only internal network and skip assigning fips

### DIFF
--- a/roles/infra/defaults/main.yml
+++ b/roles/infra/defaults/main.yml
@@ -21,13 +21,15 @@ infra_exposed_port_ranges: []
 #####
 # The ID of an existing network onto which the node should be provisioned
 # This network should be connected to an external network via a router
+# If `infra_use_floatingip` is set to `False` - an infra network
+# having connectivity from controllers is required and parameter below is mandatory.
 infra_network_id:
 # OR
 # The CIDR of the subnet that should be created
 infra_network_cidr: 192.168.100.0/24
 # The MTU of the internal network that should be created
 # (will be set to cloud default if left undefined)
-infra_network_mtu: 
+infra_network_mtu:
 # The ID of the external network to connect to via a router
 infra_external_network_id: >-
   {{-
@@ -43,12 +45,16 @@ infra_external_network_id: >-
 #   * A provisioning network
 #   * A fixed floating IP
 #   * A floating IP from a pool
+#   * An infra network without exposing any services to public network
+#     (Requires value for `infra_network_id` and `infra_use_floatingip: False`)
 #
 # If none are given, the name of the external network is used as the floating IP pool
 #
 # In the case where a provisioning network is used, the seed has two NICs - one on the provisioning
 # network and one on the internal network above
 #####
+# Use floating IPs - default, unless infra network is to be used without exposing endpoints in public network.
+infra_use_floatingip: True
 # The ID of the provisioning network to use
 infra_provisioning_network_id:
 # OR
@@ -57,7 +63,6 @@ infra_fixed_floatingip:
 # OR
 # The name of the floating IP pool
 infra_floatingip_pool:
-
 #####
 # Configuration for the image to use for the seed node
 #

--- a/roles/infra/templates/outputs.tf.j2
+++ b/roles/infra/templates/outputs.tf.j2
@@ -6,12 +6,16 @@ output "cluster_ssh_private_key" {
 
 output "cluster_gateway_ip" {
   description = "The IP address of the gateway used to contact the cluster nodes"
-{% if infra_provisioning_network_id %}
-  value = openstack_networking_port_v2.port_provisioning.all_fixed_ips[0]
-{% elif infra_fixed_floatingip %}
+{% if not infra_provisioning_network_id and infra_use_floatingip %}
+{% if infra_fixed_floatingip %}
   value = "{{ infra_fixed_floatingip }}"
 {% else %}
   value = openstack_networking_floatingip_v2.fip.address
+{% endif %}
+{% elif infra_provisioning_network_id %}
+  value = openstack_networking_port_v2.port_provisioning.all_fixed_ips[0]
+{% else %}
+  value = openstack_networking_port_v2.port_internal.all_fixed_ips[0]
 {% endif %}
 }
 
@@ -31,7 +35,7 @@ output "cluster_nodes" {
           k3s_storage_device = openstack_compute_volume_attach_v2.data_volume_attach.device
 
           # Set the gateway IP as a fact that can be consumed
-{% if not infra_provisioning_network_id %}
+{% if not infra_provisioning_network_id and infra_use_floatingip %}
 {% if infra_fixed_floatingip %}
           infra_external_ip = "{{ infra_fixed_floatingip }}"
 {% else %}

--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -140,7 +140,7 @@ resource "openstack_compute_volume_attach_v2" "data_volume_attach" {
   volume_id   = openstack_blockstorage_volume_v3.data_volume.id
 }
 
-{% if not infra_provisioning_network_id %}
+{% if not infra_provisioning_network_id and infra_use_floatingip %}
 {% if not infra_fixed_floatingip %}
 {% if not infra_floatingip_pool %}
 data "openstack_networking_network_v2" "external_net" {


### PR DESCRIPTION
Added new variable `infra_use_floatingip` allowing to skip allocation of floating IPs using only infra network for deployment and Magnum communication.

 - infra_use_floatingip defaults to `True` to retain current defaults
 - abovementioned parameter set to `False` should be used along with `infra_network_id` pointing to internal provider network accessible from controllers that is used both for nodes and Magnum internal connectivity. `capi_cluster_apiserver_floating_ip` might also be set to `False` in the environment.
 
 Replaces https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/pull/597