### PR TITLE
Bump infra image to Jammy 20241002 release

### DIFF
--- a/roles/infra/defaults/main.yml
+++ b/roles/infra/defaults/main.yml
@@ -74,9 +74,9 @@ infra_floatingip_pool:
 infra_image_id:
 # OR
 # The name of the image to upload (should be changed when the image changes)
-infra_image_name: ubuntu-jammy-20240701
+infra_image_name: ubuntu-jammy-20241002
 # The source URL for the image
-infra_image_source_url: https://cloud-images.ubuntu.com/releases/jammy/release-20240701/ubuntu-22.04-server-cloudimg-amd64.img
+infra_image_source_url: https://cloud-images.ubuntu.com/releases/jammy/release-20241002/ubuntu-22.04-server-cloudimg-amd64.img
 # The disk format of the image as downloaded
 infra_image_source_disk_format: qcow2
 # The container format for the image


### PR DESCRIPTION
Tested upgrade to this image on a single-node and it works.