### PR TITLE
Bump slurm to v1.154

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -100,7 +100,7 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/ansible-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: v1.153.1
+azimuth_caas_stackhpc_slurm_appliance_git_version: v1.154
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 # The timeout to apply to the k8s jobs which create, update & delete platform instances


### PR DESCRIPTION
Includes https://github.com/stackhpc/ansible-slurm-appliance/pull/457 which pulls in https://github.com/azimuth-cloud/ansible-collection-terraform/pull/16 to fix issue with waiting for connections on cluster