### PR TITLE
Update LLM app chart name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 backend.tf
 .vscode/
 __pycache__
+**/.DS_Store

--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -846,7 +846,7 @@ azimuth_capi_operator_app_templates_binderhub_spec:
 # Indicates whether the Zenith-enabled huggingface_llm app template should be enabled
 azimuth_capi_operator_app_templates_huggingface_llm_enabled: true
 # The Helm chart to use for the huggingface_llm app template
-azimuth_capi_operator_app_templates_huggingface_llm_chart_name: azimuth-llm
+azimuth_capi_operator_app_templates_huggingface_llm_chart_name: azimuth-llm-chat
 # The Helm repository to use for the huggingface_llm app template
 azimuth_capi_operator_app_templates_huggingface_llm_chart_repo: https://stackhpc.github.io/azimuth-llm
 # The version range to use for the huggingface_llm Helm chart


### PR DESCRIPTION
As part of https://github.com/stackhpc/azimuth-llm/pull/51 the Azimuth app was moved into a separate wrapper chart (with backwards compatibility for now) so we need to update the default chart name in the app template too.