### PR TITLE
Revert CAPO to v0.10.5

### DIFF
--- a/roles/clusterapi/defaults/main.yml
+++ b/roles/clusterapi/defaults/main.yml
@@ -42,6 +42,17 @@ clusterapi_manifests:
 
 # List of patches to apply to the resources in the manifests
 clusterapi_patches:
+  # Remove the caBundle from the CAPO custom resource definitions
+  # It is injected by cert-manager and causes validation issues if set outside of that
+  # The CAPI CRDs do not have the field set in the manifests that are shipped
+  # The caBundle exists on every CRD _except_ openstackfloatingippools
+  - patch: |-
+      - op: remove
+        path: /spec/conversion/webhook/clientConfig/caBundle
+    target:
+      kind: CustomResourceDefinition
+      labelSelector: cluster.x-k8s.io/provider=infrastructure-openstack
+      name: openstack(cluster|machine).*
   # The manifests contain environment variable substitutions for feature gates that we do not need
   - patch: |-
       - op: replace

--- a/roles/clusterapi/defaults/main.yml
+++ b/roles/clusterapi/defaults/main.yml
@@ -7,7 +7,7 @@ clusterapi_core_components: "{{ clusterapi_core_repo }}/releases/download/{{ clu
 
 # The repo, version and manifest URL for the Cluster API OpenStack provider components
 clusterapi_openstack_repo: https://github.com/kubernetes-sigs/cluster-api-provider-openstack
-clusterapi_openstack_version: v0.11.3
+clusterapi_openstack_version: v0.10.5
 clusterapi_openstack_components: "{{ clusterapi_openstack_repo }}/releases/download/{{ clusterapi_openstack_version }}/infrastructure-components.yaml"
 
 # The diagnostics address for Cluster API components


### PR DESCRIPTION
CAPO version 0.11.0 introduced a [regression](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2333) which causes OVN Octavia load balancers (e.g. those provisioned for ingress controllers and other services of type LoadBalancer) to stop working due to overly restrictive security groups. Until the issue is resolved we need cannot use any CAPO version after v0.10.5.