### PR TITLE
Update slurm to v1.157

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -100,7 +100,7 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/ansible-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: v1.155
+azimuth_caas_stackhpc_slurm_appliance_git_version: v1.157
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 # The timeout to apply to the k8s jobs which create, update & delete platform instances

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -78,10 +78,10 @@ community_images_azimuth_images: |-
 community_images_slurm_base_url: >-
   https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/openhpc-images
 community_images_slurm:
-  # from https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.154
+  # from https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.157
   openhpc:
-    name: openhpc-RL9-241022-0038-a5affa58
-    source_url: "{{ community_images_slurm_base_url }}/openhpc-RL9-241022-0038-a5affa58"
+    name: openhpc-RL9-250114-1626-bccc88b5
+    source_url: "{{ community_images_slurm_base_url }}/openhpc-RL9-250114-1626-bccc88b5"
     source_disk_format: qcow2
     container_format: bare
 


### PR DESCRIPTION
Note users will not be able to `dnf install` packages now, without a pulp configured for Azimuth