### PR TITLE
Upgrade to coral credits 0.3.6

### DIFF
--- a/roles/coral_credits/defaults/main.yml
+++ b/roles/coral_credits/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 coral_credits_chart_repo: https://stackhpc.github.io/coral-credits
 coral_credits_chart_name: coral-credits
-coral_credits_chart_version: 0.3.5
+coral_credits_chart_version: 0.3.6
 
 # Release information for the coral credits release
 coral_credits_release_namespace: "{{ azimuth_release_namespace | default('coral-credits') }}"


### PR DESCRIPTION
Because we managed to un-publish 0.3.5 by adding docs.