### PR TITLE
Revert "Update ingress-nginx to 4.12.0"

### DIFF
--- a/roles/ingress_nginx/defaults/main.yml
+++ b/roles/ingress_nginx/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 ingress_nginx_chart_repo: https://kubernetes.github.io/ingress-nginx
 ingress_nginx_chart_name: ingress-nginx
-ingress_nginx_chart_version: 4.12.0
+ingress_nginx_chart_version: 4.11.3
 
 # Release information for the NGINX ingress controller release
 ingress_nginx_release_namespace: ingress-nginx


### PR DESCRIPTION
Reverts azimuth-cloud/ansible-collection-azimuth-ops#729

This seems to have broken CaaS platform provisioning. Zenith subdomains for CaaS services do not work correctly and so platform provisioning times out. Need to investigate further.