### PR TITLE
Fix repo2docker new version home title test

### DIFF
--- a/roles/generate_tests/defaults/main.yml
+++ b/roles/generate_tests/defaults/main.yml
@@ -110,7 +110,7 @@ generate_tests_caas_test_case_slurm_service_monitoring_expected_title: Grafana
 #   We pick a repository that has some meat but is relatively quick to build
 generate_tests_caas_test_case_repo2docker_param_cluster_repository: https://github.com/binder-examples/conda.git
 #   Expected titles for the repo2docker services
-generate_tests_caas_test_case_repo2docker_service_repo2docker_expected_title: JupyterLab
+generate_tests_caas_test_case_repo2docker_service_repo2docker_expected_title: Home
 generate_tests_caas_test_case_repo2docker_service_monitoring_expected_title: Grafana
 
 # Expected titles for the rstudio services, if enabled


### PR DESCRIPTION
https://github.com/azimuth-cloud/azimuth-images/issues/175

New version of repo2docker breaks appliance testing because repo2docker containers now open to Home rather than JupyterLab. 

Testing adjusted to reflect this.