### PR TITLE
Fixed Keycloak role failing on repeat runs

### DIFF
--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -338,7 +338,7 @@
     validate_certs: "{{ keycloak_validate_certs }}"
     status_code: [204]
   when:
-    - keycloak_realm_users_req is defined
+    - not keycloak_realm_users_req.skipped
     - keycloak_bootstrap_admin_username in (keycloak_realm_users_req.json | map(attribute="username"))
   vars:
     keycloak_bootstrap_admin_user_id: >-

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -338,7 +338,7 @@
     validate_certs: "{{ keycloak_validate_certs }}"
     status_code: [204]
   when:
-    - not keycloak_realm_users_req.skipped
+    - keycloak_realm_users_req.json is defined
     - keycloak_bootstrap_admin_username in (keycloak_realm_users_req.json | map(attribute="username"))
   vars:
     keycloak_bootstrap_admin_user_id: >-


### PR DESCRIPTION
`keycloak_realm_users_req` is defined with status information even when skipped, previously leading to the non-existent `keycloak_realm_users_req.json` being referenced on repeat runs and failing. Now checks if json field is defined rather than entire object