### PR TITLE
Bump slurm to v1.160 to allow dnf installs

### DIFF
--- a/roles/azimuth_caas_operator/defaults/main.yml
+++ b/roles/azimuth_caas_operator/defaults/main.yml
@@ -100,7 +100,7 @@ azimuth_caas_stackhpc_slurm_appliance_enabled: "{{ azimuth_clusters_enabled }}"
 # The git URL for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_git_url: https://github.com/stackhpc/ansible-slurm-appliance.git
 # The git version for the StackHPC Slurm appliance
-azimuth_caas_stackhpc_slurm_appliance_git_version: v1.159
+azimuth_caas_stackhpc_slurm_appliance_git_version: v1.160
 # The playbook to use for the StackHPC Slurm appliance
 azimuth_caas_stackhpc_slurm_appliance_playbook: ansible/site.yml
 # The timeout to apply to the k8s jobs which create, update & delete platform instances


### PR DESCRIPTION
The `azimuth` user on Slurm platforms can be permitted to install dnf packages by providing credentials for StackHPC's Ark Pulp mirror:

1. [Create Ark credentials](https://github.com/stackhpc/stackhpc-release-train-clients/actions/workflows/create-client-credentials.yml) using the `stackhpc-dev` group, and by convention prefixing the client username with `caas-`.

2. Configure caas slurm platforms to use these via extravars:
```yaml
azimuth_caas_stackhpc_slurm_appliance_extra_vars_overrides:
  dnf_repos_enabled: true
  dnf_repos_username: $CLIENT_USERNAME
  dnf_repos_password: "{{ vault_dnf_repos_password }}"
  dnf_repos_allow_insecure_creds: true
```

3. Add the `vault_dnf_repos_password` value to `secrets.yml` in azimuth-config.
Note the variable [appliances_extra_packages_other](https://github.com/stackhpc/ansible-slurm-appliance/blob/main/docs/operations.md#adding-additional-packages) could also be added to the extravars to define a package list to install for all Slurm clusters.
> [!WARNING]
> This will expose Ark credentials to the `azimuth` user.