### PR TITLE
Add config drive to the infra VM

### DIFF
--- a/roles/infra/templates/resources.tf.j2
+++ b/roles/infra/templates/resources.tf.j2
@@ -94,6 +94,7 @@ resource "openstack_compute_keypair_v2" "keypair_deploy" {
 
 resource "openstack_compute_instance_v2" "node" {
   name      = "{{ infra_name }}"
+  config_drive            = true
 
 {% if infra_root_volume_enabled %}
   block_device {


### PR DESCRIPTION
This helps when we have issues with the metadata service being unable to bootstrap the VM. Adding this removes a possible failure mode.