### PR TITLE
Fail if k3s storage device is missing instead of skipping device setup

### DIFF
--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -5,27 +5,29 @@
     path: "{{ k3s_storage_device }}"
   register: k3s_storage_device_stat
 
-- name: Configure k3s storage device
-  block:
-    - name: Ensure filesystem exists on storage device
-      filesystem:
-        fstype: "{{ k3s_storage_fstype }}"
-        dev: "{{ k3s_storage_device }}"
-    
-    - name: Mount filesystem at required location
-      mount:
-        src: "{{ k3s_storage_device }}"
-        fstype: "{{ k3s_storage_fstype }}"
-        path: /var/lib/rancher/k3s
-        state: mounted
+- name: Fail if k3s storage device is missing
+  fail:
+    msg: "K3s storage device not found at {{ k3s_storage_device }}"
+  when: not k3s_storage_device_stat.stat.exists
 
-    # XFS requires the filesystem to be mounted to do this
-    - name: Grow filesystem to fill available space
-      filesystem:
-        fstype: "{{ k3s_storage_fstype }}"
-        dev: "{{ k3s_storage_device }}"
-        resizefs: true
-  when: k3s_storage_device_stat.stat.exists
+- name: Ensure filesystem exists on storage device
+  filesystem:
+    fstype: "{{ k3s_storage_fstype }}"
+    dev: "{{ k3s_storage_device }}"
+
+- name: Mount filesystem at required location
+  mount:
+    src: "{{ k3s_storage_device }}"
+    fstype: "{{ k3s_storage_fstype }}"
+    path: /var/lib/rancher/k3s
+    state: mounted
+
+# XFS requires the filesystem to be mounted to do this
+- name: Grow filesystem to fill available space
+  filesystem:
+    fstype: "{{ k3s_storage_fstype }}"
+    dev: "{{ k3s_storage_device }}"
+    resizefs: true
 
 - name: Download k3s binary
   get_url:


### PR DESCRIPTION
Prevents an issue where an OpenStack error with storage device configuration can lead to creating a new k3s cluster during Azimuth upgrades rather than re-adopting an existing cluster state from the Cinder data volume.

Tested by setting [this line](https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/blob/d8af90794a9f7d3405d5444af7e8c3b40ba3c847/roles/infra/templates/outputs.tf.j2#L35) to `k3s_storage_device = foo` which fails as intended:
```
TASK [azimuth_cloud.azimuth_ops.k3s : Check if k3s storage device is attached] ********************************************************************************
ok: [azimuth-scott-dev]

TASK [azimuth_cloud.azimuth_ops.k3s : Fail if k3s storage device is missing] **********************************************************************************
fatal: [azimuth-scott-dev]: FAILED! => {"changed": false, "msg": "K3s storage device not found at foo"}
```