### PR TITLE
BUG: Skip CaaS steps in provisioning when CaaS is disabled

### DIFF
--- a/roles/azimuth/tasks/main.yml
+++ b/roles/azimuth/tasks/main.yml
@@ -50,10 +50,12 @@
 - name: List CaaS clusters
   command: kubectl get clusters.caas -A -o json
   register: azimuth_caas_clusters_list
+  when: azimuth_clusters_enabled
 
 - name: Move clusters that are in old-style namespaces
   include_tasks:
     file: move-caas-cluster.yml
+  when: azimuth_clusters_enabled
   loop: >-
     {{
       azimuth_caas_clusters_list.stdout |


### PR DESCRIPTION
Closes https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/issues/861

Skips the steps `List CaaS Clusters` and `Move clusters that are in old-style namespaces` when `azimuth_clusters_enabled` is set to `false`; hence preventing provisioning from failing.