### PR TITLE
Added federated auth flow to Keycloak

### DIFF
--- a/roles/crossplane/defaults/main.yml
+++ b/roles/crossplane/defaults/main.yml
@@ -16,7 +16,7 @@ crossplane_providers: "{{ crossplane_providers_defaults + crossplane_providers_e
 crossplane_providers_defaults:
   - name: keycloak
     package: xpkg.upbound.io/crossplane-contrib/provider-keycloak
-    version: v1.5.0
+    version: v2.1.0
 crossplane_providers_extra: []
 
 crossplane_keycloak_provider_config_creds:
@@ -25,9 +25,11 @@ crossplane_keycloak_provider_config_creds:
   password: "{{ hostvars[groups['azimuth_deploy'][0]].keycloak_admin_password }}"
   url: "{{ hostvars[groups['azimuth_deploy'][0]].keycloak_base_url }}"
 
+crossplane_keycloak_provider_config_name: keycloak-config
+
 crossplane_provider_configurations: "{{ crossplane_provider_configurations_default + crossplane_provider_configurations_extra }}"
 crossplane_provider_configurations_default:
-  - providerConfigName: keycloak-config
+  - providerConfigName: "{{ crossplane_keycloak_provider_config_name }}"
     credentialsSecretName: keycloak-credentials
     providerApiVersion: keycloak.crossplane.io/v1beta1
     credentialsSecretKeyName: credentials

--- a/roles/crossplane/tasks/main.yml
+++ b/roles/crossplane/tasks/main.yml
@@ -75,3 +75,45 @@
             key: "{{ item.credentialsSecretKeyName }}"
             namespace: "{{ crossplane_release_namespace }}"
   with_items: "{{ crossplane_provider_configurations }}"
+
+- name: Install Keycloak federated auth flow
+  command: kubectl apply -f -
+  args:
+    stdin: "{{ item | to_nice_yaml }}"
+  loop:
+    - apiVersion: authenticationflow.keycloak.crossplane.io/v1alpha1
+      kind: Flow
+      metadata:
+        name: map-users-flow
+      spec:
+        forProvider:
+          alias: map-users-flow
+          realmId: azimuth-users
+        providerConfigRef:
+          name: "{{ crossplane_keycloak_provider_config_name }}"
+    - apiVersion: authenticationflow.keycloak.crossplane.io/v1alpha1
+      kind: Execution
+      metadata:
+        name: existing-broker-user-execution
+      spec:
+        forProvider:
+          parentFlowAlias: map-users-flow
+          realmId: azimuth-users
+          authenticator: idp-detect-existing-broker-user
+          requirement: REQUIRED
+          priority: 0
+        providerConfigRef:
+          name: "{{ crossplane_keycloak_provider_config_name }}"
+    - apiVersion: authenticationflow.keycloak.crossplane.io/v1alpha1
+      kind: Execution
+      metadata:
+        name: autolink-execution
+      spec:
+        forProvider:
+          parentFlowAlias: map-users-flow
+          realmId: azimuth-users
+          authenticator: idp-auto-link
+          requirement: REQUIRED
+          priority: 1
+        providerConfigRef:
+          name: "{{ crossplane_keycloak_provider_config_name }}"


### PR DESCRIPTION
Uses crossplane resources to add an authentication flow to map users from OIDC brokers to Keycloak users based on their email addresses. Can be used by configuring a social provider in Keycloak and then selecting 'map-users-flow' as the 'First login flow override'