### PR TITLE
Make Crossplane dependent on OIDC being enabled

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -38,7 +38,7 @@
     - role: azimuth_cloud.azimuth_ops.keycloak
       when: azimuth_apps_enabled
     - role: azimuth_cloud.azimuth_ops.crossplane
-      when: azimuth_apps_enabled
+      when: azimuth_apps_enabled and azimuth_authentication_type == "oidc"
     - role: azimuth_cloud.azimuth_ops.zenith
       when: azimuth_apps_enabled
     - role: azimuth_cloud.azimuth_ops.coral_credits


### PR DESCRIPTION
Currently backup and restore fails due to ordering issues with Crossplane CRD installations https://github.com/azimuth-cloud/azimuth-config/actions/runs/16367045671/job/46257272129#step:13:2056 . Needs fixing properly but disabling by default in CI to avoid blocking release for now