### PR TITLE
Fix regex expression in ansible changed_when field (#919)

### DIFF
--- a/roles/azimuth_capi_operator/tasks/main.yml
+++ b/roles/azimuth_capi_operator/tasks/main.yml
@@ -62,7 +62,7 @@
   loop_control:
     label: "{{ item.metadata.name }}"
   register: kubectl_patch_acl_annotations
-  changed_when: kubectl_patch_acl_annotations.stdout_lines | select('match', '(?!.*\\(no change\\)$') | length > 0
+  changed_when: kubectl_patch_acl_annotations.stdout_lines | select('match', '(?!.*\\(no change\\)$)') | length > 0
 
 - name: Deprecate non-current templates
   ansible.builtin.command: >-
@@ -81,7 +81,7 @@
   loop_control:
     label: "{{ item.metadata.name }}"
   register: kubectl_patch_templates
-  changed_when: kubectl_patch_templates.stdout_lines | select('match', '(?!.*\\(no change\\)$') | length > 0
+  changed_when: kubectl_patch_templates.stdout_lines | select('match', '(?!.*\\(no change\\)$)') | length > 0
 
 - name: Install Azimuth CAPI app templates
   ansible.builtin.command: kubectl apply -f -


### PR DESCRIPTION
* Proposed fix for regex.

Deploy 0.16.2 leads to the following error:

```
TASK [azimuth_cloud.azimuth_ops.azimuth_capi_operator : Apply ACL annotations to non-current templates] ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: re.error: missing ), unterminated subpattern at position 0
fatal: [azimuth-cl2-seed]: FAILED! => {"msg": "Unexpected failure during module execution: missing ), unterminated subpattern at position 0", "stdout": ""}
```
It seems the regex negative lookahead isn't correctly formatted, this change fixes that

* Changes requested