### PR TITLE
BUG: Find k3s device from volume ID instead of trusting openstack

### DIFF
--- a/roles/infra/templates/outputs.tf.j2
+++ b/roles/infra/templates/outputs.tf.j2
@@ -32,7 +32,7 @@ output "cluster_nodes" {
 {% endfor %}
         ]
         facts  = {
-          k3s_storage_device = openstack_compute_volume_attach_v2.data_volume_attach.device
+          k3s_storage_volume_id = openstack_compute_volume_attach_v2.data_volume_attach.volume_id
 
           # Set the gateway IP as a fact that can be consumed
 {% if not infra_provisioning_network_id and infra_use_floatingip %}

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -7,7 +7,6 @@ k3s_binary_checksum_url: "{{ k3s_repo }}/releases/download/{{ k3s_version }}/sha
 k3s_binary_checksum: "sha256:{{ lookup('url', k3s_binary_checksum_url, wantlist=True) | first | split | first }}"
 
 # Settings for an additional block device that will hold the k3s state, if present
-k3s_storage_device: /dev/sdb
 k3s_storage_fstype: xfs
 
 # Indicates if the Traefik ingress controller should be enabled

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -1,13 +1,41 @@
 ---
-- name: Check if k3s storage device is attached
-  ansible.builtin.stat:
-    path: "{{ k3s_storage_device }}"
-  register: k3s_storage_device_stat
+- name: Find the block device for the k3s storage volume
+  block:
+    - name: Stat candidate device paths
+      ansible.builtin.stat:
+        path: "/dev/disk/by-id/{{ item }}"
+      loop:
+        # KVM
+        - "{{ 'virtio-{}'.format(k3s_storage_volume_id[:20]) }}"
+        # KVM #852
+        - "{{ 'virtio-{}'.format(k3s_storage_volume_id) }}"
+        # KVM virtio-scsi
+        - "{{ 'scsi-0QEMU_QEMU_HARDDISK_{}'.format(k3s_storage_volume_id[:20]) }}"
+        # KVM virtio-scsi #852
+        - "{{ 'scsi-0QEMU_QEMU_HARDDISK_{}'.format(k3s_storage_volume_id) }}"
+        # ESXi
+        - "{{ 'wwn-0x{}'.format(k3s_storage_volume_id | replace('-', '')) }}"
+      register: candidate_device_paths_stat
 
-- name: Fail if k3s storage device is missing
-  ansible.builtin.fail:
-    msg: "K3s storage device not found at {{ k3s_storage_device }}"
-  when: not k3s_storage_device_stat.stat.exists
+    - name: Set volume block device name
+      ansible.builtin.set_fact:
+        k3s_storage_device: >-
+          /dev/{{
+            candidate_device_paths_stat.results |
+              selectattr("stat.exists") |
+              map(attribute = "stat.lnk_source") |
+              first |
+              default("") |
+              trim("/") |
+              split("/") |
+              last
+          }}
+
+    - name: Fail if block device was not found
+      ansible.builtin.fail:
+        msg: "Could not locate block device for volume {{ k3s_storage_volume_id }}."
+      when: k3s_storage_device == "/dev/"
+
 
 - name: Ensure filesystem exists on storage device
   community.general.filesystem:


### PR DESCRIPTION
`openstack_compute_volume_attach_v2.data_volume_attach.device` is often wrong at provision time and [should not be trusted](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/1.46.0/docs/resources/compute_volume_attach_v2#attributes-reference)


Instead,[ the same approach used in azimuth-images](https://github.com/azimuth-cloud/azimuth-images/blob/6e77476f1c97d547c1bb6f26fb82a7c8bf230176/ansible/roles/linux-data-volumes/files/data-volumes-configure-volume.yml#L15-L29) should be used, finding the device from the volume ID.

This avoids errors like:
```
TASK [azimuth_cloud.azimuth_ops.k3s : Fail if k3s storage device is missing] **************************************************************************************************************************
fatal: [azimuth-stfc-dev]: FAILED! => {"changed": false, "msg": "K3s storage device not found at /dev/vdb"}
```
when the hypervisor chooses the mount the volume in a different mount than Terraform/OpenStack is expecting.

<img width="600" height="127" alt="image" src="https://github.com/user-attachments/assets/8c1ae071-34f5-4417-8b06-6606da1a5b4b" />

<img width="490" height="28" alt="image" src="https://github.com/user-attachments/assets/580a7049-639c-430a-9afd-fd5b4860d907" />
