### PR TITLE
Add workaround for services added to existing cluster post-upgrade not working

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -51,8 +51,8 @@
       when: azimuth_apps_enabled
     - role: azimuth_cloud.azimuth_ops.azimuth
 
-  # Ensure that Consul is uninstalled
   post_tasks:
+    # Ensure that Consul is uninstalled
     - name: Ensure Consul is uninstalled
       ansible.builtin.include_role:
         name: azimuth_cloud.azimuth_ops.consul
@@ -60,5 +60,13 @@
       when:
         - consul_server_host is defined
         - consul_server_port is defined
+    # Workaround for new services on existing Clusters not getting added
+    # to Platforms after upgrades
+    - name: Restart CAPI Operator
+      ansible.builtin.include_role:
+        name: azimuth_cloud.azimuth_ops.azimuth_capi_operator
+        tasks_from: restart.yml
+      when: azimuth_kubernetes_enabled
+
   environment:
     KUBECONFIG: "{{ kubeconfig_path | default('') }}"

--- a/roles/azimuth_capi_operator/tasks/restart.yml
+++ b/roles/azimuth_capi_operator/tasks/restart.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart deployment
+  ansible.builtin.command: "kubectl rollout restart deployment {{ azimuth_capi_operator_release_name }} -n {{ azimuth_capi_operator_release_namespace }}"


### PR DESCRIPTION
Due to a currently unresolved bug in the CAPI operator where, after an upgrade, new services added to an existing Cluster's status field aren't propagated through to Platforms, these services can't be reached through the Azimuth UI.
Added a workaround to avoid blocking the next release