### PR TITLE
Fix backup CI failing from not finding Velero CRDs + revert k3s to 1.31.13

### DIFF
--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 
 k3s_repo: https://github.com/k3s-io/k3s
-k3s_version: v1.33.1+k3s1
+k3s_version: v1.31.13+k3s1
 k3s_binary_url: "{{ k3s_repo }}/releases/download/{{ k3s_version }}/k3s"
 k3s_binary_checksum_url: "{{ k3s_repo }}/releases/download/{{ k3s_version }}/sha256sum-amd64.txt"
-k3s_binary_checksum: "sha256:{{ lookup('url', k3s_binary_checksum_url, wantlist=True) | first | split | first }}"
+k3s_binary_checksum: "sha256:{{ lookup('url', k3s_binary_checksum_url, wantlist=True) | select('match', '.+k3s$') | first | split | first }}"
 
 # Settings for an additional block device that will hold the k3s state, if present
 k3s_storage_device: /dev/sdb

--- a/roles/velero/tasks/restore.yml
+++ b/roles/velero/tasks/restore.yml
@@ -6,6 +6,9 @@
       --output jsonpath='{.status.phase}'
   changed_when: false
   register: velero_target_backup_check
+  until: velero_target_backup_check.rc == 0
+  retries: 18
+  delay: 10
 
 - name: Fail if target backup is not in an allowable state
   ansible.builtin.fail:


### PR DESCRIPTION
A couple of fixes to ensure the backup + restore CI passes

- As the version of kubectl is based on the seed's k3s version, kubectl can become incompatible with the CAPI cluster if the two drift more than one minor version. Reverted k3s to v1.31.13 to amend this
- Added retry loop to backup check step in Velero role. Previously this could fail due to delays in the backup CRD being pulled from the S3 bucket
- Edited k3s defaults to ensure correct checksum is pulled regardless of its position in the upstream file