### PR TITLE
Continue to deploy Ingress NGINX addon

### DIFF
--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -381,7 +381,10 @@ capi_cluster_release_defaults:
     # The NGINX ingress controller is required
     ingress:
       enabled: "{{ capi_cluster_addons_ingress_enabled }}"
+      traefik:
+        enabled: false
       nginx:
+        enabled: true
         release:
           values:
             controller:


### PR DESCRIPTION
In 0.23.0 release of capi-helm-charts, the default ingress controller has changed to Traefik. We're not currently ready for that here, so continue to install Ingress NGINX.