### PR TITLE
Maintain NGINX ingress deployment in capi-operator defaults

### DIFF
--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -249,6 +249,11 @@ azimuth_capi_operator_capi_helm_values_defaults:
   authWebhook: "{{ 'azimuth-authorization-webhook' if azimuth_authentication_type == 'oidc' else 'none' }}"
   azimuthAuthorizationWebhook: "{{ azimuth_capi_operator_capi_helm_azimuth_authorization_webhook_config if azimuth_authentication_type == 'oidc' else {} }}"
   addons:
+    ingress:
+      traefik:
+        enabled: false
+      nginx:
+        enabled: true
     openstack:
       # General OpenStack configuration
       cloudConfig:


### PR DESCRIPTION
Since 0.23.0 of capi-helm-charts, the default ingress controller is now Traefik.

Ensure that clusters with ingress enabled still deploy NGINX as we are not ready to support the LoadBalancerIP configuration in azimuth-capi-operator yet [1].

[1] https://github.com/azimuth-cloud/azimuth-capi-operator/pull/564