### PR TITLE
Fix CI generating app tests for unused apptemplates CRD

### DIFF
--- a/playbooks/generate_tests.yml
+++ b/playbooks/generate_tests.yml
@@ -36,7 +36,7 @@
       changed_when: false
 
     - name: Get installed Kubernetes app templates
-      ansible.builtin.command: kubectl get apptemplates -o json
+      ansible.builtin.command: kubectl get apptemplates.azimuth.stackhpc.com -o json
       register: generate_tests_app_templates_cmd
       changed_when: false
 


### PR DESCRIPTION
`kubectl get apptemplates` now defaults to the currently unused FluxCD based apptemplates, meaning existing apptemplates don't get tested in CI