### PR TITLE
Verify checksums for existing images and use community-visibility images from other projects

### DIFF
--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -10,7 +10,6 @@ community_images_openstack_cli_path: >-
 # The directory into which images will be downloaded / converted
 # If not given, a temporary directory will be used
 community_images_workdir:
-
 # OpenStack credentials for uploading images
 # The value of the OS_CLOUD environment variable to use
 community_images_os_cloud: >-
@@ -94,10 +93,16 @@ community_images_slurm:
     source_disk_format: qcow2
     container_format: bare
 
-community_images_share_trusted_community_images: true
-
+# Skips verifying the Glance os_hash_value properties of existing images on the cloud
+# Insecure, but may be required if not supported by Openstack config
 community_images_insecure_skip_glance_verify: false
-
+# Indicates whether to look for community-visibility images from other projects,
+# community_images_insecure_skip_glance_verify must be false
+# to use this functionality
+community_images_share_trusted_community_images: true
+# Hash algorithm to verify Glance images with. Must match os_hash_algo value of images
+# and must be sha256 or sha512. If these requirements can't be satisfied, set
+# community_images_insecure_skip_glance_verify: true
 community_images_glance_checksum_algo: sha512
 
 # The default community images to upload

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -72,6 +72,7 @@ community_images_azimuth_images: |-
       "name": "{{ image.name }}",
       "source_url": "{{ image.url }}",
       "checksum": "{{ image.checksum }}",
+      "checksum_sha512": "{{ image.checksum_sha512 }}",
       "source_disk_format": "qcow2",
       "container_format": "bare",
       {% if "kubernetes_version" in image %}
@@ -92,6 +93,12 @@ community_images_slurm:
     source_url: "{{ community_images_slurm_base_url }}/openhpc-RL9-260306-0934-45b9a589"
     source_disk_format: qcow2
     container_format: bare
+
+community_images_share_trusted_community_images: true
+
+community_images_insecure_skip_glance_verify: false
+
+community_images_glance_checksum_algo: sha256
 
 # The default community images to upload
 community_images_default: >-

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -99,11 +99,7 @@ community_images_insecure_skip_glance_verify: false
 # Indicates whether to look for community-visibility images from other projects,
 # community_images_insecure_skip_glance_verify must be false
 # to use this functionality
-community_images_share_trusted_community_images: true
-# Hash algorithm to verify Glance images with. Must match os_hash_algo value of images
-# and must be sha256 or sha512. If these requirements can't be satisfied, set
-# community_images_insecure_skip_glance_verify: true
-community_images_glance_checksum_algo: sha512
+community_images_use_existing_trusted_community_images: true
 
 # The default community images to upload
 community_images_default: >-

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -98,7 +98,7 @@ community_images_share_trusted_community_images: true
 
 community_images_insecure_skip_glance_verify: false
 
-community_images_glance_checksum_algo: sha256
+community_images_glance_checksum_algo: sha512
 
 # The default community images to upload
 community_images_default: >-

--- a/roles/community_images/tasks/upload_image.yml
+++ b/roles/community_images/tasks/upload_image.yml
@@ -28,11 +28,67 @@
     image list -f json
     --name {{ community_images_image_spec.name }}
   changed_when: false
-  register: community_images_image_list_cmd
+  register: community_images_project_image_list_cmd
+
+- name: "List images from other projects with name - {{ community_images_image_spec.name }}"
+  ansible.builtin.command: >-
+    {{ community_images_openstack_cli_path }}
+    image list -f json --community
+    --name {{ community_images_image_spec.name }}
+  changed_when: false
+  register: community_images_community_image_list_cmd
 
 - name: "Set image list fact - {{ community_images_image_spec.name }}"
   ansible.builtin.set_fact:
-    community_images_image_list: "{{ community_images_image_list_cmd.stdout | from_json }}"
+    community_images_image_list: "{{ _community_images_project_image_list if _community_images_use_images_in_project else _community_images_project_image_list }}"
+  vars:
+    _community_images_project_image_list: "{{ community_images_project_image_list_cmd.stdout | from_json }}"
+    _community_images_community_image_list: "{{ community_images_community_image_list_cmd.stdout | from_json }}"
+    _community_images_use_images_in_project: _community_images_project_image_list | length > 0 or not community_images_share_trusted_community_images
+
+- name: Verify existing images
+  when:
+    - not community_images_insecure_skip_glance_verify
+    - community_images_image_list | length > 0
+    - community_images_image_spec.checksum_sha512 is defined
+  block:
+    - name: Get Glance checksums
+      ansible.builtin.command: >-
+        {{ community_images_openstack_cli_path }}
+        image show -f json
+        {{ _image_id }}
+      loop: "{{ community_images_image_list | map(attribute='ID') }}"
+      loop_control:
+        loop_var: _image_id
+      register: _community_images_show_cmd
+
+    - name: Set glance checksum as fact
+      ansible.builtin.set_fact:
+        community_images_glance_checksum_list: "{{ _community_images_show_cmd.results | map(attribute='stdout') | map('from_json') | map(attribute='properties.os_hash_value') }}"
+      
+    - name: Check using secure hashing algorithm
+      ansible.builtin.assert:
+        that: community_images_glance_checksum_algo in ['sha256','sha512']
+        fail_msg: "Glance os_hash_algo must be sha256 or sha512"
+
+    - name: Verify Glance checksums
+      block:
+      - name: "Ensure all Glance checksums of images named {{ community_images_image_spec.name }} are the same"
+        ansible.builtin.assert:
+          that: "{{ community_images_glance_checksum_list | unique | length == 1 }}"
+          fail_msg: |
+            Expecting a single image with name {{ community_images_image_spec.name }} and
+            os_hash_value {{ _community_images_image_spec_glance_checksum }}, found
+            {{ community_images_glance_checksum_list | unique }}
+      - name: Ensure Glance checksum matches manifest
+        ansible.builtin.assert:
+          that: community_images_glance_checksum_list | first == _community_images_image_spec_glance_checksum
+          fail_msg: >- 
+            Expecting os_hash_value to be {{ community_images_glance_checksum_algo }} checksum
+            {{ _community_images_image_spec_glance_checksum }}, was {{ community_images_glance_checksum_list | first }}
+      vars:
+        _community_images_image_spec_glance_checksum: "{{ community_images_image_spec.checksum_sha512 if community_images_glance_checksum_algo == 'sha512' else community_images_image_spec.checksum }}"
+
 
 - name: Get information on existing images from OpenStack
   when: "community_images_image_list | length > 0"

--- a/roles/community_images/tasks/upload_image.yml
+++ b/roles/community_images/tasks/upload_image.yml
@@ -38,13 +38,20 @@
   changed_when: false
   register: community_images_community_image_list_cmd
 
+# Images already in project take precedence over community-visibility images from other projects
 - name: "Set image list fact - {{ community_images_image_spec.name }}"
   ansible.builtin.set_fact:
-    community_images_image_list: "{{ _community_images_project_image_list if _community_images_use_images_in_project else _community_images_project_image_list }}"
+    community_images_image_list: "{{
+                                  _community_images_project_image_list
+                                  if _community_images_use_images_in_project
+                                  else _community_images_project_image_list
+                                  }}"
+  changed_when: false
   vars:
     _community_images_project_image_list: "{{ community_images_project_image_list_cmd.stdout | from_json }}"
     _community_images_community_image_list: "{{ community_images_community_image_list_cmd.stdout | from_json }}"
-    _community_images_use_images_in_project: _community_images_project_image_list | length > 0 or not community_images_share_trusted_community_images
+    _community_images_use_images_in_project: _community_images_project_image_list | length > 0 or not community_images_share_trusted_community_images or
+      community_images_insecure_skip_glance_verify
 
 - name: Verify existing images
   when:
@@ -60,38 +67,46 @@
       loop: "{{ community_images_image_list | map(attribute='ID') }}"
       loop_control:
         loop_var: _image_id
+      changed_when: false
       register: _community_images_show_cmd
 
     - name: Set glance checksum as fact
       ansible.builtin.set_fact:
-        community_images_glance_checksum_list: "{{ _community_images_show_cmd.results | map(attribute='stdout') | map('from_json') | map(attribute='properties.os_hash_value') }}"
-      
+        community_images_glance_checksum_list: "{{
+          _community_images_show_cmd.results
+          | map(attribute='stdout')
+          | map('from_json')
+          | map(attribute='properties.os_hash_value')
+          }}"
+
     - name: Check using secure hashing algorithm
       ansible.builtin.assert:
         that: community_images_glance_checksum_algo in ['sha256','sha512']
         fail_msg: "Glance os_hash_algo must be sha256 or sha512"
 
     - name: Verify Glance checksums
-      block:
-      - name: "Ensure all Glance checksums of images named {{ community_images_image_spec.name }} are the same"
-        ansible.builtin.assert:
-          that: "{{ community_images_glance_checksum_list | unique | length == 1 }}"
-          fail_msg: |
-            Expecting a single image with name {{ community_images_image_spec.name }} and
-            os_hash_value {{ _community_images_image_spec_glance_checksum }}, found
-            {{ community_images_glance_checksum_list | unique }}
-      - name: Ensure Glance checksum matches manifest
-        ansible.builtin.assert:
-          that: _glance_checksum == _community_images_image_spec_glance_checksum
-          fail_msg: >- 
-            Expecting os_hash_value to be {{ community_images_glance_checksum_algo }} checksum
-            {{ _community_images_image_spec_glance_checksum }}, was {{ _glance_checksum }}
-        vars:
-          _glance_checksum: "{{ community_images_glance_checksum_list | first }}"
       vars:
-        _community_images_image_spec_glance_checksum: "{{ ( community_images_image_spec.checksum_sha512 if community_images_glance_checksum_algo == 'sha512' else community_images_image_spec.checksum).split(':')[1] }}"
-
-
+        _community_images_image_spec_glance_checksum: "{{
+                                                      ( community_images_image_spec.checksum_sha512
+                                                      if community_images_glance_checksum_algo == 'sha512' else
+                                                      community_images_image_spec.checksum).split(':')[1]
+                                                      }}"
+      block:
+        - name: "Ensure all Glance checksums are the same for of images named {{ community_images_image_spec.name }}"
+          ansible.builtin.assert:
+            that: "{{ community_images_glance_checksum_list | unique | length == 1 }}"
+            fail_msg: |
+              Expecting a single image with name {{ community_images_image_spec.name }} and
+              os_hash_value {{ _community_images_image_spec_glance_checksum }}, found
+              {{ community_images_glance_checksum_list | unique }}
+        - name: Ensure Glance checksum matches manifest
+          ansible.builtin.assert:
+            that: _glance_checksum == _community_images_image_spec_glance_checksum
+            fail_msg: >-
+              Expecting os_hash_value to be {{ community_images_glance_checksum_algo }} checksum
+              {{ _community_images_image_spec_glance_checksum }}, was {{ _glance_checksum }}
+          vars:
+            _glance_checksum: "{{ community_images_glance_checksum_list | first }}"
 - name: Get information on existing images from OpenStack
   when: "community_images_image_list | length > 0"
   block:

--- a/roles/community_images/tasks/upload_image.yml
+++ b/roles/community_images/tasks/upload_image.yml
@@ -50,7 +50,7 @@
   vars:
     _community_images_project_image_list: "{{ community_images_project_image_list_cmd.stdout | from_json }}"
     _community_images_community_image_list: "{{ community_images_community_image_list_cmd.stdout | from_json }}"
-    _community_images_use_images_in_project: _community_images_project_image_list | length > 0 or not community_images_share_trusted_community_images or
+    _community_images_use_images_in_project: _community_images_project_image_list | length > 0 or not community_images_use_existing_trusted_community_images or
       community_images_insecure_skip_glance_verify
 
 - name: Verify existing images
@@ -79,32 +79,27 @@
           | map(attribute='properties.os_hash_value')
           }}"
 
-    - name: Check using secure hashing algorithm
-      ansible.builtin.assert:
-        that: community_images_glance_checksum_algo in ['sha256','sha512']
-        fail_msg: "Glance os_hash_algo must be sha256 or sha512"
-
     - name: Verify Glance checksums
       vars:
-        _community_images_image_spec_glance_checksum: "{{
-                                                      ( community_images_image_spec.checksum_sha512
-                                                      if community_images_glance_checksum_algo == 'sha512' else
-                                                      community_images_image_spec.checksum).split(':')[1]
-                                                      }}"
+        _community_images_image_spec_glance_checksum: "{{ community_images_image_spec.checksum_sha512.split(':')[1] }}"
       block:
-        - name: "Ensure all Glance checksums are the same for of images named {{ community_images_image_spec.name }}"
+        - name: "Ensure all Glance checksums are the same for images named {{ community_images_image_spec.name }}"
           ansible.builtin.assert:
             that: "{{ community_images_glance_checksum_list | unique | length == 1 }}"
             fail_msg: |
               Expecting a single image with name {{ community_images_image_spec.name }} and
               os_hash_value {{ _community_images_image_spec_glance_checksum }}, found
-              {{ community_images_glance_checksum_list | unique }}
+              {{ community_images_glance_checksum_list | unique }}. Ensure that duplicate, untrusted images
+              are unused and if so remove them with `openstack image delete`, or ensure a new set of trusted, per-project images
+              are pulled by setting `community_images_use_existing_trusted_community_images: false`.
         - name: Ensure Glance checksum matches manifest
           ansible.builtin.assert:
             that: _glance_checksum == _community_images_image_spec_glance_checksum
             fail_msg: >-
-              Expecting os_hash_value to be {{ community_images_glance_checksum_algo }} checksum
-              {{ _community_images_image_spec_glance_checksum }}, was {{ _glance_checksum }}
+              Expecting os_hash_value to be sha512 checksum
+              {{ _community_images_image_spec_glance_checksum }}, was {{ _glance_checksum }}. Ensure the untrusted image is unused
+              and if so remove it with `openstack image delete`. A new set of trusted, per-project images
+              are pulled by setting `community_images_use_existing_trusted_community_images: false`.
           vars:
             _glance_checksum: "{{ community_images_glance_checksum_list | first }}"
 - name: Get information on existing images from OpenStack

--- a/roles/community_images/tasks/upload_image.yml
+++ b/roles/community_images/tasks/upload_image.yml
@@ -82,12 +82,14 @@
             {{ community_images_glance_checksum_list | unique }}
       - name: Ensure Glance checksum matches manifest
         ansible.builtin.assert:
-          that: community_images_glance_checksum_list | first == _community_images_image_spec_glance_checksum
+          that: _glance_checksum == _community_images_image_spec_glance_checksum
           fail_msg: >- 
             Expecting os_hash_value to be {{ community_images_glance_checksum_algo }} checksum
-            {{ _community_images_image_spec_glance_checksum }}, was {{ community_images_glance_checksum_list | first }}
+            {{ _community_images_image_spec_glance_checksum }}, was {{ _glance_checksum }}
+        vars:
+          _glance_checksum: "{{ community_images_glance_checksum_list | first }}"
       vars:
-        _community_images_image_spec_glance_checksum: "{{ community_images_image_spec.checksum_sha512 if community_images_glance_checksum_algo == 'sha512' else community_images_image_spec.checksum }}"
+        _community_images_image_spec_glance_checksum: "{{ ( community_images_image_spec.checksum_sha512 if community_images_glance_checksum_algo == 'sha512' else community_images_image_spec.checksum).split(':')[1] }}"
 
 
 - name: Get information on existing images from OpenStack


### PR DESCRIPTION
Depends on https://github.com/azimuth-cloud/azimuth-images/pull/441

Verifies the Glance os_hash_value property of existing images on the cloud. This functionality means that the authenticity of images can be verified, so community-visibility images from other OS projects can be safely used to avoid needing to re-download images in each project they are needed.