### PR TITLE
Change Jupyter expected page title to JupyterHub in robot tests

### DIFF
--- a/roles/generate_tests/defaults/main.yml
+++ b/roles/generate_tests/defaults/main.yml
@@ -316,7 +316,7 @@ generate_tests_kubernetes_apps_default_test_case_enabled: true
 generate_tests_kubernetes_apps_test_case_jupyterhub_services:
   - jupyterhub-azimuth
 #   The expected title for the JupyterHub app
-generate_tests_kubernetes_apps_test_case_jupyterhub_service_jupyterhub_azimuth_expected_title: JupyterLab
+generate_tests_kubernetes_apps_test_case_jupyterhub_service_jupyterhub_azimuth_expected_title: JupyterHub
 
 # Configuration for the DaskHub test case
 #   The services that will be produced by the DaskHub app


### PR DESCRIPTION
App tests have started failing because Jupyter app landing page is now the environment select page with a title of JupyterHub instead of JupyterLab