### PR TITLE
Set maximum app versions to azimuth-charts version for release

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -80,6 +80,12 @@ jobs:
             prereleases: "yes"
             version_jsonpath: azimuth_capi_operator_chart_version
 
+          - key: azimuth-charts
+            path: ./roles/azimuth_capi_operator/defaults/main.yml
+            repository: azimuth-cloud/azimuth-charts
+            prereleases: "yes"
+            version_jsonpath: azimuth_capi_operator_azimuth_charts_version
+
           - key: azimuth-identity-operator
             path: ./roles/azimuth_identity_operator/defaults/main.yml
             repository: azimuth-cloud/azimuth-identity-operator

--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -5,6 +5,10 @@ azimuth_capi_operator_chart_repo: https://azimuth-cloud.github.io/azimuth-capi-o
 azimuth_capi_operator_chart_name: azimuth-capi-operator
 azimuth_capi_operator_chart_version: 0.18.0
 
+# By default, pin versions to azimuth-charts version associated with current Azimuth release
+azimuth_capi_operator_azimuth_charts_version: 0.7.1
+azimuth_capi_operator_app_templates_default_version_range: "<={{ azimuth_capi_operator_azimuth_charts_version }}"
+
 # Release information for the CAPI operator release
 # Use the same namespace as Azimuth by default
 azimuth_capi_operator_release_namespace: "{{ azimuth_release_namespace | default('azimuth') }}"
@@ -590,7 +594,7 @@ azimuth_capi_operator_app_templates_jupyterhub_chart_name: jupyterhub-azimuth
 # The Helm repository to use for the JupyterHub app template
 azimuth_capi_operator_app_templates_jupyterhub_chart_repo: https://azimuth-cloud.github.io/azimuth-charts
 # The version range to use for the JupyterHub Helm chart
-azimuth_capi_operator_app_templates_jupyterhub_version_range: ">=0.0.0"
+azimuth_capi_operator_app_templates_jupyterhub_version_range: "{{ azimuth_capi_operator_app_templates_default_version_range }}"
 # Overrides for the label, logo and description from the JupyterHub Helm chart
 azimuth_capi_operator_app_templates_jupyterhub_label:
 azimuth_capi_operator_app_templates_jupyterhub_logo:
@@ -655,7 +659,7 @@ azimuth_capi_operator_app_templates_daskhub_chart_name: daskhub-azimuth
 # The Helm repository to use for the DaskHub app template
 azimuth_capi_operator_app_templates_daskhub_chart_repo: https://azimuth-cloud.github.io/azimuth-charts
 # The version range to use for the DaskHub Helm chart
-azimuth_capi_operator_app_templates_daskhub_version_range: ">=0.0.0"
+azimuth_capi_operator_app_templates_daskhub_version_range: "{{ azimuth_capi_operator_app_templates_default_version_range }}"
 # Overrides for the label, logo and description from the DaskHub Helm chart
 azimuth_capi_operator_app_templates_daskhub_label:
 azimuth_capi_operator_app_templates_daskhub_logo:
@@ -720,7 +724,7 @@ azimuth_capi_operator_app_templates_kubeflow_chart_name: kubeflow-azimuth
 # The Helm repository to use for the kubeflow app template
 azimuth_capi_operator_app_templates_kubeflow_chart_repo: https://azimuth-cloud.github.io/azimuth-charts
 # The version range to use for the kubeflow Helm chart
-azimuth_capi_operator_app_templates_kubeflow_version_range: ">=0.0.0"
+azimuth_capi_operator_app_templates_kubeflow_version_range: "{{ azimuth_capi_operator_app_templates_default_version_range }}"
 # Overrides for the label, logo and description from the kubeflow Helm chart
 azimuth_capi_operator_app_templates_kubeflow_label:
 azimuth_capi_operator_app_templates_kubeflow_logo:
@@ -785,7 +789,7 @@ azimuth_capi_operator_app_templates_binderhub_chart_name: binderhub-azimuth
 # The Helm repository to use for the binderhub app template
 azimuth_capi_operator_app_templates_binderhub_chart_repo: https://azimuth-cloud.github.io/azimuth-charts
 # The version range to use for the binderhub Helm chart
-azimuth_capi_operator_app_templates_binderhub_version_range: ">=0.0.0"
+azimuth_capi_operator_app_templates_binderhub_version_range: "{{ azimuth_capi_operator_app_templates_default_version_range }}"
 # Overrides for the label, logo and description from the binderhub Helm chart
 azimuth_capi_operator_app_templates_binderhub_label:
 azimuth_capi_operator_app_templates_binderhub_logo:
@@ -1086,7 +1090,7 @@ azimuth_capi_operator_app_templates_argocd_chart_name: argocd-azimuth
 # The Helm repository to use for the argocd app template
 azimuth_capi_operator_app_templates_argocd_chart_repo: https://azimuth-cloud.github.io/azimuth-charts
 # The version range to use for the argocd Helm chart
-azimuth_capi_operator_app_templates_argocd_version_range: ">=0.0.0"
+azimuth_capi_operator_app_templates_argocd_version_range: "{{ azimuth_capi_operator_app_templates_default_version_range }}"
 # Overrides for the label, logo and description from the argocd Helm chart
 azimuth_capi_operator_app_templates_argocd_label:
 azimuth_capi_operator_app_templates_argocd_logo:


### PR DESCRIPTION
Currently app templates are set to pull the latest versions of charts periodically, meaning changes which haven't been tested in e2e CI get automatically pulled into client sites. This change sets their maximum version to an azimuth-charts release associated with a given azimuth-ops release.

Excluded huggingface and danswer for now since unsure on what current usage is and/or preferred model