### PR TITLE
Set quotas for Harbor proxy cache projects by default

### DIFF
--- a/roles/harbor/defaults/main.yml
+++ b/roles/harbor/defaults/main.yml
@@ -101,6 +101,12 @@ harbor_persistence_pvc_redis_size: 1Gi
 harbor_persistence_pvc_registry_size: 5Gi
 harbor_persistence_pvc_trivy_size: 5Gi
 
+harbor_proxy_cache_set_quotas: true
+# Global default size for proxy cache projects, can be overridden per-project. Defaults
+# to 80% of registry volume size, split evenly between projects
+harbor_default_proxy_cache_quota: >-
+  {{ ( harbor_persistence_pvc_registry_size | replace('i','B') | human_to_bytes * 0.8 / (harbor_proxy_cache_projects.keys() | length)) | int }}
+
 # The values for the Harbor release
 harbor_release_defaults:
   caBundleSecretName: >-
@@ -174,3 +180,4 @@ harbor_proxy_cache_projects: {}
   #   name: dockerhub-public
   #   type: docker-hub
   #   url: https://hub.docker.com
+  #   quota: "{{ harbor_default_proxy_cache_quota }}"

--- a/roles/harbor/tasks/proxy_cache_project.yml
+++ b/roles/harbor/tasks/proxy_cache_project.yml
@@ -104,3 +104,52 @@
         status_code:
           - 201
       changed_when: true
+
+- name: Set quota for proxy cache project
+  when: harbor_proxy_cache_set_quotas
+  block:
+    - name: Get project ID
+      ansible.builtin.uri:
+        # checkov:skip=CKV2_ANSIBLE_1: TLS is optional
+        # checkov:skip=CKV_ANSIBLE_1: Certificate validation is optional
+        url: "{{ harbor_external_url }}/api/v2.0/projects/{{ project.name }}"
+        method: GET
+        user: admin
+        password: "{{ harbor_admin_password }}"
+        force_basic_auth: true
+        ca_path: "{{ harbor_ca_path }}"
+        validate_certs: "{{ harbor_validate_certs }}"
+      register: harbor_project
+
+    - name: Get quota ID
+      ansible.builtin.uri:
+        # checkov:skip=CKV2_ANSIBLE_1: TLS is optional
+        # checkov:skip=CKV_ANSIBLE_1: Certificate validation is optional
+        url: "{{ harbor_external_url }}/api/v2.0/quotas?reference_id={{ harbor_project.json.project_id }}"
+        method: GET
+        user: admin
+        password: "{{ harbor_admin_password }}"
+        force_basic_auth: true
+        ca_path: "{{ harbor_ca_path }}"
+        validate_certs: "{{ harbor_validate_certs }}"
+      register: harbor_quota_list
+
+    - name: Set quota for project
+      ansible.builtin.uri:
+        # checkov:skip=CKV2_ANSIBLE_1: TLS is optional
+        # checkov:skip=CKV_ANSIBLE_1: Certificate validation is optional
+        url: "{{ harbor_external_url }}/api/v2.0/quotas/{{ (harbor_quota_list.json | first).id }}"
+        method: PUT
+        user: admin
+        password: "{{ harbor_admin_password }}"
+        force_basic_auth: true
+        ca_path: "{{ harbor_ca_path }}"
+        validate_certs: "{{ harbor_validate_certs }}"
+        body_format: json
+        body: >-
+          {
+            "hard": {
+              "storage": {{ project.quota | default(harbor_default_proxy_cache_quota) }}
+            }
+          }
+      changed_when: true


### PR DESCRIPTION
Currently user clusters are able to pull arbitrary sized images into Harbor proxy caches by default, potentially exceeding the storage of the Harbor registry volume and causing it to crash. This is a particular problem for AI clouds where users sometimes pull ~1TB models as images.
Adds options to set quotas for proxy cache projects in config and defaults to splitting 80% of the Harbor registry's volume size evenly between each proxy cache project 