### PR TITLE
Plat 1106 auth registry

### DIFF
--- a/.github/workflows/test-azimuth.yml
+++ b/.github/workflows/test-azimuth.yml
@@ -28,6 +28,7 @@ jobs:
           azimuth-ops-version: ${{ github.event.pull_request.head.sha }}
           target-cloud: ${{ vars.TARGET_CLOUD }}
           install-mode: ${{ inputs.install-mode }}
+          ref: PLAT-1106-auth-registry
         # GitHub terminates jobs after 6 hours
         # We don't want jobs to acquire the lock then get timed out before they can finish
         # So wait a maximum of 3 hours to acquire the lock, leaving 3 hours for other tasks in the job

--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -301,7 +301,7 @@ capi_cluster_release_defaults:
         else {}
       }}
   trustedCAs: "{{ capi_cluster_trust_bundle }}"
-  registryAuth: "{{ capi_cluster_registry_auth }}"
+  registryAuth: "{{ capi_cluster_registry_auth | items2dict(key_name='registry_url', value_name='basic_auth') }}"
   registryMirrors: "{{ capi_cluster_registry_mirrors }}"
   apiServer: >-
     {{-

--- a/roles/harbor/defaults/main.yml
+++ b/roles/harbor/defaults/main.yml
@@ -29,6 +29,8 @@ harbor_ingress_base_domain: >-
   }}
 # The subdomain to use for the core service
 harbor_ingress_subdomain_core: "{{ ingress_harbor_core_subdomain | default('registry') }}"
+# The ingress class name to use for harbor ingress
+harbor_ingress_class: "nginx"
 # The host to use for the core service
 harbor_ingress_host_core: "{{ harbor_ingress_subdomain_core }}.{{ harbor_ingress_base_domain }}"
 # The subdomain to use for the notary service
@@ -120,6 +122,7 @@ harbor_release_defaults:
       hosts:
         core: "{{ harbor_ingress_host_core }}"
         notary: "{{ harbor_ingress_host_notary }}"
+      className: "{{ harbor_ingress_class }}"
       annotations: >-
         {{-
           (harbor_ingress_annotations | combine(harbor_tls_ingress_annotations))

--- a/roles/harbor/tasks/main.yml
+++ b/roles/harbor/tasks/main.yml
@@ -73,6 +73,29 @@
   retries: 60
   delay: 10
 
+- name: Create proxy user
+  # checkov:skip=CKV2_ANSIBLE_1: TLS is optional
+  # checkov:skip=CKV_ANSIBLE_1: Certificate validation is optional
+  ansible.builtin.uri:
+    url: "{{ harbor_external_url }}/api/v2.0/users"
+    method: POST
+    user: admin
+    password: "{{ harbor_admin_password }}"
+    force_basic_auth: true
+    body_format: json
+    headers:
+      X-Is-Resource-Name: true
+    body:
+      username: proxy
+      password: "{{ harbor_proxy_password }}"
+      realname: "Docker proxy cache user"
+      comment: "Docker proxy cache user"
+      email: "notreal@email.com"
+    ca_path: "{{ harbor_ca_path }}"
+    validate_certs: "{{ harbor_validate_certs }}"
+    status_code:
+      - 201
+
 - name: Create proxy cache projects
   ansible.builtin.include_tasks: proxy_cache_project.yml
   loop: "{{ harbor_proxy_cache_projects.values() }}"

--- a/roles/harbor/tasks/proxy_cache_project.yml
+++ b/roles/harbor/tasks/proxy_cache_project.yml
@@ -104,3 +104,29 @@
         status_code:
           - 201
       changed_when: true
+
+    - name: Add proxy user to proxy cache project
+      ansible.builtin.uri:
+        # checkov:skip=CKV_ANSIBLE_1: Certificate validation is optional
+        url: "{{ harbor_external_url }}/api/v2.0/projects/{{ project.name }}/members"
+        method: POST
+        user: admin
+        password: "{{ harbor_admin_password }}"
+        force_basic_auth: true
+        body_format: json
+        # Integers in the body are converted to strings, which causes the Harbor API to fail
+        # https://github.com/ansible/ansible/issues/59732
+        # So we have to build the JSON manually
+        # role_id: 2 corresponds to a developer account in Harbor
+        body: >-
+          {
+            "role_id": 2,
+            "member_user": {
+              "username": "proxy"
+            }
+          }
+        ca_path: "{{ harbor_ca_path }}"
+        validate_certs: "{{ harbor_validate_certs }}"
+        status_code:
+          - 201
+      changed_when: true

--- a/roles/harbor/tasks/proxy_cache_project.yml
+++ b/roles/harbor/tasks/proxy_cache_project.yml
@@ -94,7 +94,7 @@
           {
             "project_name": "{{ project.name }}",
             "registry_id": {{ harbor_registry.id }},
-            "public": true,
+            "public": false,
             "metadata": {
               "auto_scan": "true"
             }


### PR DESCRIPTION
Add basic authentication to the proxy used for the upstream docker.io proxy. 

PR #344 in azimuth-config shows the required structure for registry authentication.