### PR TITLE
sealed-secrets/defaults/main.yml: Update sealed secrets chart repo

### DIFF
--- a/roles/sealed_secrets/defaults/main.yml
+++ b/roles/sealed_secrets/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-sealed_secrets_chart_repo: https://bitnami-labs.github.io/sealed-secrets
+sealed_secrets_chart_repo: https://bitnami.github.io/sealed-secrets
 sealed_secrets_chart_name: sealed-secrets
 sealed_secrets_chart_version: 2.18.5
 


### PR DESCRIPTION
Bitnami are migrating the repository for sealed-secrets from `github.com/bitnami-labs/sealed-secrets` to `github.com/bitnami/sealed-secrets` as per https://github.com/bitnami/sealed-secrets/issues/1982. Update our `sealed_secrets_chart_repo` reference to point to the new URL.