### PR TITLE
Expose workerNodeSecurityGroupRules and controlPlaneNodesSecurityGroupRules

### DIFF
--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -187,6 +187,35 @@ azimuth_capi_operator_capi_helm_csi_cinder_default_availability_zone: nova
 # The Cinder volume type for the default Cinder CSI storage class
 azimuth_capi_operator_capi_helm_csi_cinder_default_volume_type:
 
+# The list of security group rules that should be applied to
+# worker nodes on clouds with Octavia loadbalancer provider OVN
+azimuth_capi_operator_capi_helm_worker_node_security_group_rules_ovn:
+  - name: Worker nodePort TCP
+    remoteIPPrefix: 0.0.0.0/0
+    protocol: tcp
+    direction: ingress
+    etherType: IPv4
+    portRangeMin: 30000
+    portRangeMax: 32767
+  - name: Worker nodePort UDP
+    protocol: udp
+    remoteIPPrefix: 0.0.0.0/0
+    direction: ingress
+    etherType: IPv4
+    portRangeMin: 30000
+    portRangeMax: 32767
+
+# Defines the rules that should be applied to worker nodes
+azimuth_capi_operator_capi_helm_worker_node_security_group_rules: >-
+  {{-
+    azimuth_capi_operator_capi_helm_worker_node_security_group_rules_ovn
+    if azimuth_capi_operator_capi_helm_openstack_loadbalancer_provider == 'ovn'
+    else []
+  }}
+
+# Defines the rules that should be applied to control-plane nodes
+azimuth_capi_operator_capi_helm_control_plane_node_security_group_rules: []
+
 azimuth_capi_operator_capi_helm_values_defaults:
   machineMetadata: "{{ azimuth_capi_operator_capi_helm_machine_metadata }}"
   kubeNetwork:
@@ -213,6 +242,16 @@ azimuth_capi_operator_capi_helm_values_defaults:
         combine(
           { "dnsNameservers": azimuth_capi_operator_capi_helm_dns_nameservers }
           if azimuth_capi_operator_capi_helm_dns_nameservers
+          else {}
+        ) |
+        combine(
+          { "workerNodeSecurityGroupRules": azimuth_capi_operator_capi_helm_worker_node_security_group_rules }
+          if azimuth_capi_operator_capi_helm_worker_node_security_group_rules | length > 0
+          else {}
+        ) |
+        combine(
+          { "controlPlaneNodesSecurityGroupRules": azimuth_capi_operator_capi_helm_control_plane_node_security_group_rules }
+          if azimuth_capi_operator_capi_helm_control_plane_node_security_group_rules | length > 0
           else {}
         )
     }}

--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -3,7 +3,7 @@
 # The chart to use
 azimuth_capi_operator_chart_repo: https://azimuth-cloud.github.io/azimuth-capi-operator
 azimuth_capi_operator_chart_name: azimuth-capi-operator
-azimuth_capi_operator_chart_version: 0.20.1
+azimuth_capi_operator_chart_version: 0.21.0
 
 # By default, pin versions to azimuth-charts version associated with current Azimuth release
 azimuth_capi_operator_azimuth_charts_version: 0.10.0

--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -2,7 +2,7 @@
 # The chart to use
 capi_cluster_chart_repo: https://azimuth-cloud.github.io/capi-helm-charts
 capi_cluster_chart_name: openstack-cluster
-capi_cluster_chart_version: 0.25.1
+capi_cluster_chart_version: 0.26.0
 
 # Release information for the cluster release
 capi_cluster_release_namespace: default

--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -254,6 +254,12 @@ capi_cluster_addons_monitoring_prometheus_external_url: >-
     else ""
   }}
 
+# Defines the rules that should be applied to worker nodes
+capi_cluster_worker_node_security_group_rules: []
+
+# Defines the rules that should be applied to control-plane nodes
+capi_cluster_control_plane_node_security_group_rules: []
+
 # The values for the release
 capi_cluster_release_defaults:
   kubernetesVersion: "{{ capi_cluster_kubernetes_version }}"
@@ -285,6 +291,16 @@ capi_cluster_release_defaults:
           if capi_cluster_external_network_id
           else {},
           recursive = True
+        ) |
+        combine(
+          { "workerNodeSecurityGroupRules": capi_cluster_worker_node_security_group_rules }
+          if capi_cluster_worker_node_security_group_rules | length > 0
+          else {}
+        ) |
+        combine(
+          { "controlPlaneNodesSecurityGroupRules": capi_cluster_control_plane_node_security_group_rules }
+          if capi_cluster_control_plane_node_security_group_rules | length > 0
+          else {}
         )
     }}
   kubeNetwork:


### PR DESCRIPTION
Expose workerNodeSecurityGroupRules and controlPlaneNodesSecurityGroupRules for both the Azimuth management capi_cluster, and in the values passed to capi-helm-charts/openstack-cluster by the azimuth-capi-operator.

When using the OVN Octavia load-balancer provider, set workerNodeSecurityGroupRules on capi-helm-charts/openstack-clusters to permit traffic originating from outside the cluster. This is required to restore the functionality removed in [1], specifically for clouds using OVN load-balancers [2].

These rules only need to be applied to azimuth-capi-operator clusters, because the same security group rules are created on the capi_cluster by capi-helm-charts when apiServer.loadBalancerProvider=ovn [3], which is intended to provide convenience for configuration when using magnum-capi-helm. azimuth-capi-operator clusters do not have an apiServer.loadBalancerProvider as this is provided by Zenith running in the Azimuth management cluster, and external to capi-helm-charts configuration.

These rules are only required to allow ingress traffic to reach worker nodes, specifically in the case where OpenStack Cloud Controller Manager has created an Octavia pool and pool members in response to a LoadBalancer service resource. Kubernetes API traffic originating outside of the azimuth-capi-operator cluster and directed towards control-plane nodes travels down a Zenith SSH tunnel, so there is no requirement to account for it in security group rules.

[1] https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2128
[2] https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2333
[3] https://github.com/azimuth-cloud/capi-helm-charts/pull/747