### PR TITLE
Ensure CAPO objects have been migrated before upgrading CAPO

### DIFF
--- a/roles/clusterapi/defaults/main.yml
+++ b/roles/clusterapi/defaults/main.yml
@@ -178,3 +178,10 @@ clusterapi_janitor_openstack_wait_timeout: 30m
 # The values for the Cluster API janitor deployment
 # The defaults are sufficient for most use cases
 clusterapi_janitor_openstack_release_values: {}
+
+# The list of CAPO resource names to ensure are migrated before a CAPO upgrade
+clusterapi_capo_migrate_resources:
+  - openstackclusters
+  - openstackclustertemplates
+  - openstackmachines
+  - openstackmachinetemplates

--- a/roles/clusterapi/tasks/main.yml
+++ b/roles/clusterapi/tasks/main.yml
@@ -11,6 +11,9 @@
     dest: "{{ clusterapi_kustomization_directory }}/kustomization.yaml"
     mode: "0644"
 
+- name: Ensure Cluster API Provider OpenStack resources are migrated
+  ansible.builtin.include_tasks: migrate-capo-resources.yml
+
 - name: Install Cluster API resources
   ansible.builtin.command: >-
     kubectl apply --force-conflicts --server-side=true -k {{ clusterapi_kustomization_directory }}

--- a/roles/clusterapi/tasks/migrate-capo-resources.yml
+++ b/roles/clusterapi/tasks/migrate-capo-resources.yml
@@ -1,0 +1,34 @@
+---
+
+- name: List CRDs
+  ansible.builtin.command: >-
+    kubectl get deployments -n capo-system -o custom-columns=NAME:.metadata.name
+  register: cluster_crds
+  changed_when: false
+
+- name: Get running capo-controller-manager image and tag
+  ansible.builtin.command: >-
+    kubectl get -n capo-system deployments/capo-controller-manager -o jsonpath="{..image}"
+  register: clusterapi_capo_image
+  failed_when: false
+  changed_when: false
+
+- name: Migrate CAPO objects when upgrading CAPO
+  when:
+    - clusterapi_capo_image.rc == 0
+  block:
+    - name: Extract running capo-controller-manager tag
+      ansible.builtin.set_fact:
+        clusterapi_running_capo_version: "{{ clusterapi_capo_image.stdout_lines[0] | split(':') | last }}"
+
+    - name: Ensure that CAPO object migrations have occurred
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        kubectl get {{ item }} -A -o json | kubectl replace -f -
+      args:
+        executable: /bin/bash
+      when:
+        - item in cluster_crds.stdout_lines
+        - clusterapi_openstack_version is version(clusterapi_running_capo_version, '>')
+      loop: "{{ clusterapi_capo_migrate_resources }}"
+      changed_when: true


### PR DESCRIPTION
Potential fix for

> "kubectl", "apply", "--force-conflicts", "--server-side=true", "-k", "/home/ubuntu/clusterapi"], "delta": "0:00:20.635265", "end": "2026-06-22 14:40:50.273642", "msg": "non-zero return code", "rc": 1, "start": "2026-06-22 14:40:29.638377", "stderr": "Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io \"openstackclusters.infrastructure.cluster.x-k8s.io\" is invalid: status.storedVersions[0]: Invalid value: \"v1alpha7\": missing from spec.versions; v1alpha7 was previously a storage version, and must remain in spec.versions until a storage migration ensures no data remains persisted in v1alpha7 and removes v1alpha7 from status.storedVersions\nError from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io \"openstackclustertemplates.infrastructure.cluster.x-k8s.io\" is invalid: status.storedVersions[0]: Invalid value: \"v1alpha7\": missing from spec.versions; v1alpha7 was previously a storage version, and must remain in spec.versions until a storage migration ensures no data remains persisted in v1alpha7 and removes v1alpha7 from status.storedVersions\nError from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io \"openstackmachines.infrastructure.cluster.x-k8s.io\" is invalid: status.storedVersions[0]: Invalid value: \"v1alpha7\": missing from spec.versions; v1alpha7 was previously a storage version, and must remain in spec.versions until a storage migration ensures no data remains persisted in v1alpha7 and removes v1alpha7 from status.storedVersions\nError from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io \"openstackmachinetemplates.infrastructure.cluster.x-k8s.io\" is invalid: status.storedVersions[0]: Invalid value: \"v1alpha7\": missing from spec.versions; v1alpha7 was previously a storage version, and must remain in spec.versions until a storage migration ensures no data remains persisted in v1alpha7 and removes v1alpha7 from status.storedVersions", "stderr_lines": ["Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io \"openstackclusters.infrastructure.cluster.x-k8s.io\" is invalid: status.storedVersions[0]: Invalid value: \"v1alpha7\": missing from spec.versions; v1alpha7 was previously a storage version, and must remain in spec.version