### PR TITLE
Stop installing Sealed Secrets by default

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -15,6 +15,7 @@
     - role: azimuth_cloud.azimuth_ops.flux
       when: flux_enabled
     - role: azimuth_cloud.azimuth_ops.sealed_secrets
+      when: azimuth_authentication_type == "oidc"
     - role: azimuth_cloud.azimuth_ops.certmanager
       when: certmanager_enabled or azimuth_kubernetes_enabled
     # NOTE: this is kept to remove existing dashboard installs


### PR DESCRIPTION
Currently only used in the context of https://github.com/azimuth-cloud/azimuth-tenant-config which is unused