### PR TITLE
role/capi_cluster: Control cinder volume expansion from config

### DIFF
--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -130,6 +130,8 @@ azimuth_capi_operator_capi_helm_worker_kubeadm_verbosity: 5
 azimuth_capi_operator_capi_helm_root_volume_size:
 azimuth_capi_operator_capi_helm_control_plane_root_volume_size: "{{ azimuth_capi_operator_capi_helm_root_volume_size }}"
 azimuth_capi_operator_capi_helm_worker_root_volume_size: "{{ azimuth_capi_operator_capi_helm_root_volume_size }}"
+# Whether or not to allow volume expansion for the default Cinder CSI storage class
+capi_cluster_addons_csi_cinder_allow_volume_expansion: false
 # The volume type for the root disk
 # Leave blank for the default volume type
 azimuth_capi_operator_capi_helm_root_volume_type:
@@ -468,7 +470,10 @@ azimuth_capi_operator_capi_helm_values_defaults:
           {{-
             { "availabilityZone": azimuth_capi_operator_capi_helm_csi_cinder_default_availability_zone } |
               combine(
-                { "volumeType": azimuth_capi_operator_capi_helm_csi_cinder_default_volume_type }
+                {
+                  "volumeType": azimuth_capi_operator_capi_helm_csi_cinder_default_volume_type,
+                  "allowVolumeExpansion": capi_cluster_addons_csi_cinder_allow_volume_expansion
+                }
                 if azimuth_capi_operator_capi_helm_csi_cinder_default_volume_type
                 else {}
               )

--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -196,6 +196,8 @@ capi_cluster_addons_openstack_block_storage_rescan_on_resize:
 capi_cluster_addons_openstack_block_storage_ignore_volume_az: true
 # The availability zone for the default Cinder CSI storage class
 capi_cluster_addons_csi_cinder_availability_zone: nova
+# Whether or not to allow volume expansion for the default Cinder CSI storage class
+capi_cluster_addons_csi_cinder_allow_volume_expansion: false
 # The Cinder volume type for the default Cinder CSI storage class
 capi_cluster_addons_csi_cinder_volume_type:
 # Retention settings for Alertmanager
@@ -546,7 +548,10 @@ capi_cluster_release_defaults:
       csiCinder:
         defaultStorageClass: >-
           {{-
-            { "availabilityZone": capi_cluster_addons_csi_cinder_availability_zone } |
+            {
+              "availabilityZone": capi_cluster_addons_csi_cinder_availability_zone,
+              "allowVolumeExpansion": capi_cluster_addons_csi_cinder_allow_volume_expansion
+            } |
               combine(
                 { "volumeType": capi_cluster_addons_csi_cinder_volume_type }
                 if capi_cluster_addons_csi_cinder_volume_type


### PR DESCRIPTION
Allow enabling/disabling volume expansion of cinder volumes from the ansible configuration (and hence from the `azimuth_config`) of a deployment. By default volume expansion is enabled.