### PR TITLE
Install jq and yq on the Seed VM

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -160,6 +160,12 @@ jobs:
             prereleases: "yes"
             version_jsonpath: clusterapi_janitor_openstack_chart_version
 
+          - key: jq
+            path: ./roles/jq/defaults/main.yml
+            repository: jqlang/jq
+            tags: "yes"
+            version_jsonpath: jq_version
+
           - key: flux-cli
             path: ./roles/flux/defaults/main.yml
             repository: fluxcd/flux2
@@ -191,6 +197,11 @@ jobs:
             path: ./roles/kustomize/defaults/main.yml
             repository: kubernetes-sigs/kustomize
             version_jsonpath: kustomize_version
+
+          - key: yq
+            path: ./roles/yq/defaults/main.yml
+            repository: mikefarah/yq
+            version_jsonpath: yq_version
 
           - key: provider-keycloak
             path: ./roles/crossplane/defaults/main.yml

--- a/playbooks/provision_cluster.yml
+++ b/playbooks/provision_cluster.yml
@@ -35,6 +35,14 @@
           ansible.builtin.include_role:
             name: azimuth_cloud.azimuth_ops.k9s
 
+        - name: Install jq
+          ansible.builtin.include_role:
+            name: azimuth_cloud.azimuth_ops.jq
+
+        - name: Install yq
+          ansible.builtin.include_role:
+            name: azimuth_cloud.azimuth_ops.yq
+
         - name: Get installed Kubernetes version
           ansible.builtin.command: k3s kubectl version --output json
           changed_when: false

--- a/roles/jq/defaults/main.yml
+++ b/roles/jq/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+# The jq repository
+jq_repo: https://github.com/jqlang/jq
+# The jq version to download
+jq_version: jq-1.7.1
+# The OS variant and architecture to use
+# See https://github.com/jqlang/jq/releases for the available options
+jq_os: linux
+jq_architecture: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
+# The name of the jq binary
+jq_binary_name: "jq-{{ jq_os }}-{{ jq_architecture }}"
+# The URL of the jq binary to download
+jq_binary_url: "{{ jq_repo }}/releases/download/{{ jq_version }}/{{ jq_binary_name }}"
+
+# The directory into which the jq binary should be placed
+jq_bin_directory: /usr/local/bin

--- a/roles/jq/tasks/main.yml
+++ b/roles/jq/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Ensure bin directory exists
+  ansible.builtin.file:
+    path: "{{ jq_bin_directory }}"
+    state: directory
+    mode: "0755"
+
+- name: Download and install jq binary
+  ansible.builtin.get_url:
+    url: "{{ jq_binary_url }}"
+    dest: "{{ (jq_bin_directory, 'jq') | path_join }}"
+    mode: "0755"
+    force: true

--- a/roles/yq/defaults/main.yml
+++ b/roles/yq/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+# The yq repository
+yq_repo: https://github.com/mikefarah/yq
+# The yq version to download
+yq_version: v4.45.1
+# The OS variant and architecture to use
+# See https://github.com/mikefarah/yq/releases for the available options
+yq_os: linux
+yq_architecture: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
+# The name of the yq binary
+yq_binary_name: "yq_{{ yq_os }}_{{ yq_architecture }}"
+# The URL of the yq binary to download
+yq_binary_url: "{{ yq_repo }}/releases/download/{{ yq_version }}/{{ yq_binary_name }}"
+
+# The directory into which the yq binary should be placed
+yq_bin_directory: /usr/local/bin

--- a/roles/yq/tasks/main.yml
+++ b/roles/yq/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Ensure bin directory exists
+  ansible.builtin.file:
+    path: "{{ yq_bin_directory }}"
+    state: directory
+    mode: "0755"
+
+- name: Download and install yq binary
+  ansible.builtin.get_url:
+    url: "{{ yq_binary_url }}"
+    dest: "{{ (yq_bin_directory, 'yq') | path_join }}"
+    mode: "0755"
+    force: true


### PR DESCRIPTION
Add jq and yq roles that download pre-built binaries from GitHub Releases (`jqlang/jq` and `mikefarah/yq`), following the same pattern as `kubectl`/`k9s`/`kustomize`. Both tools are wired into `provision_cluster.yml` and tracked by the nightly update-dependencies workflow.