### PR TITLE
Pause clusters, patch workerNodesSecurityGroupRules, upgrade CAPO, unpause clusters

### DIFF
--- a/roles/azimuth_capi_operator/tasks/patch_cluster_security_group_rules.yml
+++ b/roles/azimuth_capi_operator/tasks/patch_cluster_security_group_rules.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Patch workerNodesSecurityGroupRules on OpenStackClusters
+  ansible.builtin.command: >-
+    kubectl patch openstackclusters.infrastructure.cluster.x-k8s.io {{ item.metadata.name }}
+    --namespace {{ item.metadata.namespace }}
+    --type merge
+    --patch '{{ azimuth_capi_operator_patch_security_group_clusters_patch | to_nice_json }}'
+  loop: "{{ azimuth_capi_operator_patch_security_group_clusters }}"
+  loop_control:
+    label: "{{ item.metadata.namespace }}/{{ item.metadata.name }}"
+  register: azimuth_capi_operator_patch_cluster_sg
+  changed_when: azimuth_capi_operator_patch_cluster_sg.stdout_lines | select('match', '(?!.*\\(no change\\)$)') | length > 0
+  vars:
+    azimuth_capi_operator_patch_security_group_clusters_patch: >-
+      {{
+        {
+          "spec": {
+            "managedSecurityGroups": {
+              "workerNodesSecurityGroupRules": azimuth_capi_operator_capi_helm_worker_node_security_group_rules
+              }
+            }
+          }
+      }}
+  when:
+    - azimuth_capi_operator_patch_security_group_clusters is defined

--- a/roles/clusterapi/tasks/main.yml
+++ b/roles/clusterapi/tasks/main.yml
@@ -1,4 +1,34 @@
 ---
+
+- name: Pause clusters.azimuth.stackhpc.com
+  when:
+    - openstack_loadbalancer_provider == "ovn"
+  block:
+    - name: Retrieve all clusters.azimuth.stackhpc.com
+      ansible.builtin.command: >-
+        kubectl get
+        --all-namespaces
+        -o json
+        clusters.azimuth.stackhpc.com
+      register: clusterapi_azimuth_clusters
+      changed_when: false
+      failed_when: false
+
+    - name: Set a fact containing clusters.azimuth.stackhpc.com
+      ansible.builtin.set_fact:
+        clusterapi_azimuth_clusters: >-
+          {{
+            clusterapi_azimuth_clusters.stdout
+            | from_json
+            | json_query('items')
+          }}
+
+    - name: Pause clusters.cluster.x-k8s.io
+      ansible.builtin.include_tasks: pause_unpause_reconciliation.yml
+      vars:
+        clusterapi_pause_clusters: "{{ clusterapi_azimuth_clusters }}"
+        clusterapi_should_pause_clusters: true
+
 - name: Make kustomization directory
   ansible.builtin.file:
     path: "{{ clusterapi_kustomization_directory }}"
@@ -40,6 +70,23 @@
   loop_control:
     loop_var: watch
     label: "{{ watch.namespace }}/{{ watch.kind }}/{{ watch.name }}"
+
+- name: Patch security group rules and unpause clusters
+  when:
+    - openstack_loadbalancer_provider == "ovn"
+  block:
+    - name: Patch workerNodesSecurityGroupRules on openstackclusters.infrastructure.cluster.x-k8s.io
+      ansible.builtin.include_role:
+        name: azimuth_capi_operator
+        tasks_from: patch_cluster_security_group_rules.yml
+      vars:
+        azimuth_capi_operator_patch_security_group_clusters: "{{ clusterapi_azimuth_clusters }}"
+
+    - name: Unpause clusters.cluster.x-k8s.io
+      ansible.builtin.include_tasks: pause_unpause_reconciliation.yml
+      vars:
+        clusterapi_pause_clusters: "{{ clusterapi_azimuth_clusters }}"
+        clusterapi_should_pause_clusters: false
 
 - name: Install Cluster API addon provider
   kubernetes.core.helm:

--- a/roles/clusterapi/tasks/pause_unpause_reconciliation.yml
+++ b/roles/clusterapi/tasks/pause_unpause_reconciliation.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Pause or unpause CAPI cluster reconciliation
+  ansible.builtin.command: >-
+    kubectl patch clusters.cluster {{ item.metadata.name }}
+    --namespace {{ item.metadata.namespace }}
+    --type merge
+    --patch '{{ patch | to_nice_json }}'
+  loop: "{{ clusterapi_pause_clusters }}"
+  loop_control:
+    label: "{{ item.metadata.namespace }}/{{ item.metadata.name }}/paused: {{ paused }}"
+  register: clusterapi_patch_cluster_pause
+  changed_when: clusterapi_patch_cluster_pause.stdout_lines | select('match', '(?!.*\\(no change\\)$)') | length > 0
+  vars:
+    paused: "{{ clusterapi_should_pause_clusters | default(false) }}"
+    patch: >-
+      {{
+        {"spec": {"paused": paused }}
+        }}
+    when:
+      - clusterapi_pause_clusters is defined


### PR DESCRIPTION
Recent updates to CAPO mean that worker-node security groups are too restrictive when using the OVN Provider for Octavia.

The required security group rules are already updated in capi-operator defaults, but updating CAPO immediately applies the new, restrictive security group rules to all openstackmachines. This means that capi-operator clusters that have not adopted the new capi-operator default values, because they have not been updated since CAPO has been upgraded, have the restrictive security group rules applied at the next occurance of the CAPO reconciliation loop, breaking external connectivity for clusters, particularly those using ingress.

This adds process to pause reconciliation on all clusters with before CAPO is upgraded, and a `kubectl patch` to add the correct security group rules to all clusters after CAPO is upgraded. Last, cluster reconciliation is unpaused. This is applied only when `openstack_loadbalancer_provider: ovn`.

This adds the desired state of workerNodesSecurityGroupRules to running clusters before they have been updated or upgraded via the Azimuth UI.