### PR TITLE
feat(flatcar): add Flatcar Linux support to community_images, azimuth…

### DIFF
--- a/roles/azimuth_capi_operator/defaults/main.yml
+++ b/roles/azimuth_capi_operator/defaults/main.yml
@@ -643,6 +643,20 @@ azimuth_capi_operator_release_values: >-
 # All other templates will be marked as DEPRECATED
 # azimuth-ops currently never removes templates
 #####
+# Whether to generate Flatcar Linux cluster templates.
+# When enabled, one template is created per Kubernetes version in the sysext manifest.
+# Also auto-enables KubeadmBootstrapFormatIgnition in the clusterapi role.
+azimuth_capi_operator_flatcar_enabled: false
+# URL for the Flatcar sysext manifest at the same azimuth-images version
+azimuth_capi_operator_flatcar_sysext_manifest_url: >-
+  https://raw.githubusercontent.com/azimuth-cloud/azimuth-images/{{ community_images_azimuth_images_version }}/vars/flatcar/sysext-manifest.json
+# Parsed sysext manifest - only fetched when Flatcar is enabled
+azimuth_capi_operator_flatcar_sysext_manifest: >-
+  {{
+    lookup('url', azimuth_capi_operator_flatcar_sysext_manifest_url, split_lines=False) | from_json
+    if azimuth_capi_operator_flatcar_enabled
+    else {}
+  }}
 # Tags for the default Kubernetes apps
 azimuth_capi_operator_cluster_template_tags:
   - standard
@@ -703,12 +717,51 @@ azimuth_capi_operator_cluster_templates_default: |-
     {% endif %}
     {% endfor %}
   }
+# Flatcar Linux cluster templates (one per Kubernetes version in the sysext manifest)
+azimuth_capi_operator_cluster_templates_flatcar: |-
+  {%- if azimuth_capi_operator_flatcar_enabled %}
+  {
+    {%- set containerd_version = community_images_flatcar_versions.containerd_version %}
+    {%- set containerd_sysext = azimuth_capi_operator_flatcar_sysext_manifest.containerd[containerd_version] %}
+    {%- for kube_version, kube_sysext in azimuth_capi_operator_flatcar_sysext_manifest.kubernetes.items() %}
+    {%- set kube_vn_no_prefix = kube_version | regex_replace('^v', '') %}
+    {%- set kube_vn_dash = kube_vn_no_prefix | replace('.', '-') %}
+    "kube-{{ kube_vn_dash }}-flatcar": {
+      "annotations": {{ azimuth_capi_operator_cluster_template_annotations }},
+      "spec": {{
+        azimuth_capi_operator_cluster_template_defaults |
+          combine(
+            {
+              "label": kube_version ~ " on Flatcar Linux",
+              "description": "Kubernetes " ~ kube_vn_no_prefix ~ " with HA control plane on Flatcar Linux.",
+              "values": {
+                "kubernetesVersion": kube_vn_no_prefix,
+                "osDistro": "flatcar",
+                "machineImageId": community_images_image_ids["flatcar"],
+                "flatcar": {
+                  "sysextKubernetesUrl": kube_sysext.url,
+                  "sysextKubernetesChecksum": kube_sysext.checksum,
+                  "sysextContainerdUrl": containerd_sysext.url,
+                  "sysextContainerdChecksum": containerd_sysext.checksum,
+                },
+              },
+            },
+            recursive = True
+          )
+      }},
+    },
+    {%- endfor %}
+  }
+  {%- else %}
+  {}
+  {%- endif %}
 # Allow extra templates to be defined using a separate variable
 azimuth_capi_operator_cluster_templates_extra: {}
 # The full list of Kubernetes cluster templates to install
 azimuth_capi_operator_cluster_templates: >-
   {{-
     azimuth_capi_operator_cluster_templates_default |
+      combine(azimuth_capi_operator_cluster_templates_flatcar, recursive = True) |
       combine(azimuth_capi_operator_cluster_templates_extra, recursive = True)
   }}
 

--- a/roles/clusterapi/defaults/main.yml
+++ b/roles/clusterapi/defaults/main.yml
@@ -29,7 +29,8 @@ clusterapi_feature_gate_machine_pool: false
 clusterapi_feature_gate_cluster_topology: true
 clusterapi_feature_gate_runtime_sdk: true
 clusterapi_feature_gate_machine_set_preflight_checks: true
-clusterapi_feature_gate_kubeadm_bootstrap_format_ignition: false
+clusterapi_feature_gate_kubeadm_bootstrap_format_ignition: >-
+  {{ azimuth_capi_operator_flatcar_enabled | default(False) }}
 clusterapi_feature_gate_openstack_priority_queue: true
 clusterapi_feature_gate_openstack_autoscale_from_zero: true
 

--- a/roles/community_images/defaults/main.yml
+++ b/roles/community_images/defaults/main.yml
@@ -93,6 +93,27 @@ community_images_slurm:
     source_disk_format: qcow2
     container_format: bare
 
+# Flatcar Linux images - published by azimuth-images via the flatcar-update workflow
+# URL for Flatcar version data at the same azimuth-images version as Ubuntu images
+community_images_flatcar_versions_url: >-
+  https://raw.githubusercontent.com/azimuth-cloud/azimuth-images/{{ community_images_azimuth_images_version }}/vars/flatcar/versions.json
+community_images_flatcar_versions: >-
+  {{ lookup('url', community_images_flatcar_versions_url, split_lines=False) | from_json }}
+# Empty dict when no Flatcar image has been published for this azimuth-images version
+community_images_flatcar: >-
+  {%- if community_images_flatcar_versions.flatcar_image_url %}
+  {
+    "flatcar": {
+      "name": "flatcar-stable-{{ community_images_flatcar_versions.flatcar_version }}",
+      "source_url": "{{ community_images_flatcar_versions.flatcar_image_url }}",
+      "source_disk_format": "raw",
+      "container_format": "bare"
+    }
+  }
+  {%- else %}
+  {}
+  {%- endif %}
+
 # Skips verifying the Glance os_hash_value properties of existing images on the cloud
 # Insecure, but may be required if not supported by Openstack config
 community_images_insecure_skip_glance_verify: false
@@ -103,7 +124,7 @@ community_images_use_existing_trusted_community_images: true
 
 # The default community images to upload
 community_images_default: >-
-  {{ community_images_azimuth_images | combine(community_images_slurm, recursive=True) }}
+  {{ community_images_azimuth_images | combine(community_images_flatcar, recursive=True) | combine(community_images_slurm, recursive=True) }}
 
 # Any extra community images to upload as well as the defaults
 community_images_extra: {}


### PR DESCRIPTION
## Summary

This PR wires Flatcar Linux support into the Azimuth deployment stack, behind a single opt-in flag azimuth_capi_operator_flatcar_enabled: false.

When enabled:

- community_images — fetches the Flatcar image URL from azimuth-images at community_images_azimuth_images_version and uploads it to Glance as flatcar-stable-<version>. Resolves to an empty dict if no Flatcar image has been published for that release, so the role is safe to enable before the first image is built.
- azimuth_capi_operator — fetches the sysext manifest (containerd + Kubernetes binaries with URLs and checksums) from azimuth-images and generates one ClusterTemplate per Kubernetes version: kube-<version>-flatcar. Each template sets osDistro: flatcar, pins machineImageId to the Glance Flatcar image, and injects the S3 sysext URLs and checksums for the Ignition config (consumed by capi-helm-charts).
- clusterapi — automatically enables the KubeadmBootstrapFormatIgnition feature gate on both the kubeadm bootstrap and kubeadm control plane controllers, which is required for CAPI to generate Ignition configs instead of cloud-init.

## Depends on

- azimuth-cloud/azimuth-images#481 — CI pipeline producing Flatcar images and sysext manifests
- azimuth-cloud/capi-helm-charts#770 — Ignition config template with sysext download and provider-id

## Activation

To enable Flatcar in a deployment, set in your configuration:

```yaml
azimuth_capi_operator_flatcar_enabled: true
```

No other variables need to be set — all defaults are derived from `community_images_azimuth_images_version`.