### PR TITLE
Rollback velero-plugin-for-aws to 1.14.0

### DIFF
--- a/roles/velero/defaults/main.yml
+++ b/roles/velero/defaults/main.yml
@@ -65,7 +65,7 @@ velero_cinder_snapshot_class_name: cinder-csi-snapshot
 
 # Velero plugin config
 velero_s3_plugin_image_source: velero/velero-plugin-for-aws
-velero_s3_plugin_image_version: v1.14.2
+velero_s3_plugin_image_version: v1.14.0
 
 # The default backup storage location
 # We disable checksums because older Ceph doesn't implement them properly


### PR DESCRIPTION
Version 1.14.2 requires us to provide an s3 region, which we currently don't.