### PR TITLE
roles/capi-cluster: Add the ability to skip schema validation

### DIFF
--- a/roles/capi_cluster/defaults/main.yml
+++ b/roles/capi_cluster/defaults/main.yml
@@ -11,6 +11,9 @@ capi_cluster_release_name: "{{ undef(hint='capi_cluster_release_name is required
 # The state of the cluster - present to install/update, absent to delete
 capi_cluster_release_state: present
 
+# Whether to skip validating the helm chart against the chart values schema
+capi_cluster_skip_schema_validation: false
+
 # Read the credentials for the deployment from the current clouds.yaml by default
 capi_cluster_clouds_file: >-
   {{-

--- a/roles/capi_cluster/tasks/main.yml
+++ b/roles/capi_cluster/tasks/main.yml
@@ -12,6 +12,7 @@
         release_state: present
         release_values: "{{ capi_cluster_release_values }}"
         create_namespace: true
+        skip_schema_validation: "{{ capi_cluster_skip_schema_validation }}"
       register: capi_cluster_helm_release
 
     - name: Wait for cluster to become Available


### PR DESCRIPTION
Add a variable to skip helm chart schema validation for the `openstack-cluster` helm chart pulled from `capi-helm-charts`.